### PR TITLE
Add support for ATOM addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,5 +39,6 @@ This library currently supports the following cryptocurrencies and address forma
  - BCH (base58check and cashAddr; decodes to cashAddr)
  - BNB (bech32)
  - XLM (ed25519 public key)
+ - ATOM (bech32)
 
 PRs to add additional chains and address types are welcome.

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -143,6 +143,13 @@ const vectors: Array<TestVector> = [
       { text: 'GAI3GJ2Q3B35AOZJ36C4ANE3HSS4NK7WI6DNO4ZSHRAX6NG7BMX6VJER', hex: '11b32750d877d03b29df85c0349b3ca5c6abf64786d773323c417f34df0b2fea' },
     ],
   },
+  {
+    name: 'ATOM',
+    coinType: 118,
+    passingVectors: [
+      { text: 'cosmos1depk54cuajgkzea6zpgkq36tnjwdzv4afc3d27', hex: '6e436a571cec916167ba105160474b9c9cd132bd' }
+    ],
+  },
 ];
 
 vectors.forEach((vector: TestVector) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -217,6 +217,7 @@ const formats: IFormat[] = [
   base58Chain('MONA', 22, [0x32], [0x05]),
   hexChecksumChain('ETH', 60),
   hexChecksumChain('ETC', 61),
+  bech32Chain('ATOM', 118, 'cosmos'),
   hexChecksumChain('RSK', 137, 30),
   {
     coinType: 144,
@@ -237,7 +238,6 @@ const formats: IFormat[] = [
     name: 'XLM',
   },
   bech32Chain('BNB', 714, 'bnb'),
-  bech32Chain('ATOM', 118, 'cosmos'),
 ];
 
 export const formatsByName: { [key: string]: IFormat } = Object.assign({}, ...formats.map(x => ({ [x.name]: x })));

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,6 +229,20 @@ const formats: IFormat[] = [
     encoder: stellar.StrKey.encodeEd25519PublicKey,
     name: 'XLM',
   },
+  {
+    coinType: 118,
+    decoder: (data: string) => {
+      const { prefix, words } = bech32.decode(data);
+      if (prefix !== 'cosmos') {
+        throw Error('Unrecognised address format');
+      }
+      return Buffer.from(bech32.fromWords(words));
+    },
+    encoder: (data: Buffer) => {
+      return bech32.encode('cosmos', bech32.toWords(data));
+    },
+    name: 'ATOM',
+  },
 ];
 
 export const formatsByName: { [key: string]: IFormat } = Object.assign({}, ...formats.map(x => ({ [x.name]: x })));

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,10 +193,10 @@ function makeBech32Encoder(prefix: string) {
   return (data: Buffer) => bech32.encode(prefix, bech32.toWords(data));
 }
 
-function makeBech32Decoder(_prefix: string) {
+function makeBech32Decoder(currentPrefix: string) {
   return (data: string) => {
     const { prefix, words } = bech32.decode(data);
-    if (prefix !== _prefix) {
+    if (prefix !== currentPrefix) {
       throw Error('Unrecognised address format');
     }
     return Buffer.from(bech32.fromWords(words));


### PR DESCRIPTION
Add support for ATOM addresses as defined in https://cosmos.network/docs/spec/addresses/bech32.html

Added a test using a sample cosmos address off the rpc documentation here https://cosmos.network/rpc/:
```
Address string
example: cosmos1depk54cuajgkzea6zpgkq36tnjwdzv4afc3d27
bech32 encoded address
```