### PR TITLE
Fix MONA params

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This library currently supports the following cryptocurrencies and address forma
  - BTC (base58check P2PKH and P2SH, and bech32 segwit)
  - LTC (base58check P2PHK and P2SH, and bech32 segwit)
  - DOGE (base58check P2PKH and P2SH)
- - MONA (base58check P2PKH and P2SH)
+ - MONA (base58check P2PKH and P2SH, and bech32 segwit)
  - DASH (base58check P2PKH and P2SH)
  - ETH (checksummed-hex)
  - ETC (checksummed-hex)

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -57,6 +57,8 @@ const vectors: Array<TestVector> = [
     coinType: 22,
     passingVectors: [
       { text: 'MHxgS2XMXjeJ4if2PRRbWYcdwZPWfdwaDT', hex: '76a9146e5bb7226a337fe8307b4192ae5c3fab9fa9edf588ac' },
+      { text: 'PHjTKtgYLTJ9D2Bzw2f6xBB41KBm2HeGfg', hex: 'a9146449f568c9cd2378138f2636e1567112a184a9e887' },
+      { text: 'mona1zw508d6qejxtdg4y5r3zarvaryvhm3vz7', hex: '5210751e76e8199196d454941c45d1b3a323' },
     ],
   },
   {

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,9 +192,9 @@ const hexChecksumChain = (name: string, coinType: number, chainId?: number) => (
 const formats: IFormat[] = [
   bitcoinChain('BTC', 0, 'bc', [0x00], [0x05]),
   bitcoinChain('LTC', 2, 'ltc', [0x30], [0x32, 0x05]),
-  bitcoinChain('MONA', 22, 'mona', [0x32], [0x37, 0x05]),
   base58Chain('DOGE', 3, [0x1e], [0x16]),
   base58Chain('DASH', 5, [0x4c], [0x10]),
+  bitcoinChain('MONA', 22, 'mona', [0x32], [0x37, 0x05]),
   hexChecksumChain('ETH', 60),
   hexChecksumChain('ETC', 61),
   hexChecksumChain('RSK', 137, 30),

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,8 +192,8 @@ const hexChecksumChain = (name: string, coinType: number, chainId?: number) => (
 const formats: IFormat[] = [
   bitcoinChain('BTC', 0, 'bc', [0x00], [0x05]),
   bitcoinChain('LTC', 2, 'ltc', [0x30], [0x32, 0x05]),
+  bitcoinChain('MONA', 22, 'mona', [0x32], [0x37, 0x05]),
   base58Chain('DOGE', 3, [0x1e], [0x16]),
-  base58Chain('MONA', 22, [0x32], [0x05]),
   base58Chain('DASH', 5, [0x4c], [0x10]),
   hexChecksumChain('ETH', 60),
   hexChecksumChain('ETC', 61),


### PR DESCRIPTION
Sorry.
[0x05] is old params.
Now monacoin uses [0x37].
https://github.com/wakiyamap/electrum-mona/blob/master/electrum_mona/tests/test_bitcoin.py#L362-#L376
