### PR TITLE
Add Groestlcoin (GRS) Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language : node_js
 node_js :
- - stable
+ - 10
 install:
  - npm install
 jobs:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ This library currently supports the following cryptocurrencies and address forma
  - TRX (base58check)
  - NEM (base32)
  - EOS
- - KSM (ss58)
+ - KSM (ss58) 
+ - GRS (base58check P2PKH and P2SH, and bech32 segwit)
 
 
 PRs to add additional chains and address types are welcome.

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "bech32": "^1.1.3",
-    "crypto-addr-codec": "^0.1.7"
+    "crypto-addr-codec": "^0.1.7",
+    "bs58grscheck": "^2.1.2"
   }
 }

--- a/src/@types/bs58grscheck/index.d.ts
+++ b/src/@types/bs58grscheck/index.d.ts
@@ -1,0 +1,4 @@
+declare module 'bs58grscheck' {
+  export function encode(data: Buffer): string;
+  export function decode(data: string): Buffer;
+}

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -199,7 +199,16 @@ const vectors: Array<TestVector> = [
     passingVectors: [
       { text: 'cosmos1depk54cuajgkzea6zpgkq36tnjwdzv4afc3d27', hex: '6e436a571cec916167ba105160474b9c9cd132bd' }
     ],
-  }
+  },
+  {
+    name: 'GRS',
+    coinType: 17,
+    passingVectors: [
+      { text: 'FeBhpvNkdtxC7K3LEVT8uqskzwC4mFYrhR', hex: '76a91462e907b15cbf27d5425399ebf6f0fb50ebb88f1888ac' },
+      { text: '3Ai1JZ8pdJb2ksieUV8FsxSNVJCpiWuy6m', hex: 'a91462e907b15cbf27d5425399ebf6f0fb50ebb88f1887' },
+      { text: 'grs1q9ks70lf7cz074lnn3p9ffyjfx8h0f3a8nz55sg', hex: '00142da1e7fd3ec09feafe73884a94924931eef4c7a7' },
+    ],
+  },
 ];
 
 vectors.forEach((vector: TestVector) => {


### PR DESCRIPTION
This PR will add Groestlcoin or GRS support.  Groestlcoin is a coin similar to Bitcoin in that it supports segwit, but it differs in that it uses a different hash algorithm for the checksum of addresses.

Therefore the package.json was modified to include `bs58grscheck` which is a fork of `bs58check`.  Also other additions were made to accommodate the different check for addresses.

`makeBase58GrsCheckDecoder` is added to be used instead of `makeBase58CheckDecoder`