### PR TITLE
Reduce size by at least 34%

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -771,11 +771,6 @@
       "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
       "dev": true
     },
-    "aes-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
-    },
     "ajv": {
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
@@ -949,14 +944,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
-    },
-    "axios": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.1.tgz",
-      "integrity": "sha512-Yl+7nfreYKaLRvAvjNPkvfjnQHJM1yLBY3zhqAwcJSwR/6ETkanUgylgtIvkvz0xJ+p/vZuNw8X7Hnb7Whsbpw==",
-      "requires": {
-        "follow-redirects": "1.5.10"
-      }
     },
     "babel-cli": {
       "version": "6.26.0",
@@ -2919,43 +2906,6 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
-    "ethers": {
-      "version": "4.0.43",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.43.tgz",
-      "integrity": "sha512-VjQRVgPrlU12jSMvypdE1yEqYQccdVbH8bbiz67dLF7raHlRV4+zW70GlxHcZYqgsnz0XYWrn6C06gqTQRb5tw==",
-      "requires": {
-        "aes-js": "3.0.0",
-        "bn.js": "^4.4.0",
-        "elliptic": "6.5.2",
-        "hash.js": "1.1.3",
-        "js-sha3": "0.5.7",
-        "scrypt-js": "2.0.4",
-        "setimmediate": "1.0.4",
-        "uuid": "2.0.1",
-        "xmlhttprequest": "1.8.0"
-      },
-      "dependencies": {
-        "hash.js": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "minimalistic-assert": "^1.0.0"
-          }
-        },
-        "uuid": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
-        }
-      }
-    },
-    "eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
-    },
     "events": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",
@@ -3269,24 +3219,6 @@
       "dev": true,
       "requires": {
         "locate-path": "^3.0.0"
-      }
-    },
-    "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "requires": {
-        "debug": "=3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "for-in": {
@@ -4026,6 +3958,14 @@
         "sntp": "1.x.x"
       }
     },
+    "hextronweb": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hextronweb/-/hextronweb-1.0.0.tgz",
+      "integrity": "sha512-sxwhJgOFt8tfMACdE24C1BT7Zsfh9QD0NNp5shbaTwst6HgKRv5jAmdyNBiem79cl15XKqmoAhxc8ufop99H6A==",
+      "requires": {
+        "js-sha256": "^0.9.0"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -4140,11 +4080,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "optional": true
-    },
-    "injectpromise": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/injectpromise/-/injectpromise-1.0.0.tgz",
-      "integrity": "sha512-qNq5wy4qX4uWHcVFOEU+RqZkoVG65FhvGkyDWbuBxILMjK6A1LFf5A1mgXZkD4nRx5FCorD81X/XvPKp/zVfPA=="
     },
     "inline-source-map": {
       "version": "0.6.2",
@@ -4964,10 +4899,10 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.0.0.tgz",
       "integrity": "sha1-laKpVBKRqfgZ4Bb4W6JHEW0D5Ks="
     },
-    "js-sha3": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-      "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+    "js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -6545,11 +6480,6 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
-    "scrypt-js": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
-      "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
-    },
     "secp256k1": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
@@ -6596,11 +6526,6 @@
           }
         }
       }
-    },
-    "setimmediate": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-      "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
     },
     "sha.js": {
       "version": "2.4.11",
@@ -7268,31 +7193,6 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
-    "tronweb": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/tronweb/-/tronweb-2.10.0.tgz",
-      "integrity": "sha512-9E0acSZucjHdSqKjslBVufvwpyFulyOxrR3Zfx9Y9Y3wQg6M8Pg2o+se7ZF+L9KZH7FVFBgjAeXvR421Ny8biw==",
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "axios": "^0.19.0",
-        "babel-runtime": "^6.26.0",
-        "bignumber.js": "^7.2.1",
-        "elliptic": "^6.4.1",
-        "ethers": "^4.0.7",
-        "eventemitter3": "^3.1.0",
-        "injectpromise": "^1.0.0",
-        "lodash": "^4.17.14",
-        "semver": "^5.6.0",
-        "validator": "^10.7.1"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "7.2.1",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-          "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
-        }
-      }
-    },
     "ts-jest": {
       "version": "24.1.0",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-24.1.0.tgz",
@@ -7371,10 +7271,9 @@
       }
     },
     "tslib": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "dev": true
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+      "integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
     },
     "tslint": {
       "version": "5.20.0",
@@ -7632,11 +7531,6 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
-    "validator": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
-      "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw=="
-    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -7779,11 +7673,6 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
-    },
-    "xmlhttprequest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -44,12 +44,13 @@
     "bs58check": "^2.1.2",
     "cashaddrjs": "^0.3.8",
     "eosjs-ecc": "^4.0.7",
+    "hextronweb": "^1.0.0",
+    "js-sha256": "^0.9.0",
     "nem-sdk": "^1.6.7",
     "ripple-address-codec": "^4.0.0",
     "rskjs-util": "^1.0.3",
     "safe-buffer": "^5.2.0",
     "stellar-base": "^2.1.2",
-    "tronweb": "^2.8.0",
     "tsify": "^4.0.1",
     "tslib": "^1.11.0"
   }

--- a/src/@types/hextronweb/index.d.ts
+++ b/src/@types/hextronweb/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'tronweb' {
+declare module 'hextronweb' {
 
   export namespace address {
 
@@ -6,5 +6,5 @@ declare module 'tronweb' {
     export function toHex(e: any): any;
 
   }
-  
+
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import {
   toChecksumAddress as rskToChecksumAddress } from 'rskjs-util';
 // @ts-ignore
 import { StrKey } from 'stellar-base/lib/strkey';
-import {address as tronaddress} from 'tronweb';
+import {address as tronaddress} from 'hextronweb';
 
 interface IFormat {
   coinType: number;
@@ -293,7 +293,7 @@ const formats: IFormat[] = [
     coinType: 194,
     decoder: eosAddrDecoder,
     encoder: eosAddrEncoder,
-    name: 'EOS',             
+    name: 'EOS',
   },
   {
     coinType: 195,
@@ -306,7 +306,7 @@ const formats: IFormat[] = [
     decoder: ksmAddrDecoder,
     encoder: ksmAddrEncoder,
     name: 'KSM'
-  },  
+  },
   {
     coinType: 714,
     decoder: (data: string) => {


### PR DESCRIPTION
Reduce size by at least 25%

Removing the whole TronWeb (11.3%) package and ethers (23.1%) with a new dedicated package that has only what's needed for the hex encode/decode.

https://www.npmjs.com/package/hextronweb


Just TronWeb has 655.5 kB

but HexTronWeb has only 9kB

Thank you

