### PR TITLE
adding Nano conversion logic and test for MultiCoin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language : node_js
 node_js :
- - stable
+ - 10
 install:
  - npm install
 jobs:

--- a/README.md
+++ b/README.md
@@ -55,5 +55,6 @@ This library currently supports the following cryptocurrencies and address forma
  - SOL (base58check)
  - ADA (bech32)
  - CELO (checksummed-hex)
+ - NANO (nano32)
 
 PRs to add additional chains and address types are welcome.

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "bech32": "^1.1.3",
+    "blakejs": "^1.1.0",
     "crypto-addr-codec": "^0.1.7"
   }
 }

--- a/src/@types/nano32/index.ts
+++ b/src/@types/nano32/index.ts
@@ -1,0 +1,84 @@
+// @ts-ignore
+import { blake2b } from 'blakejs'
+
+const nanoAlphabet = '13456789abcdefghijkmnopqrstuwxyz'
+
+function nanobase32(buffer: Uint8Array): string {
+  const length = buffer.length
+  const leftover = (length * 8) % 5
+  const offset = leftover === 0 ? 0 : 5 - leftover
+  let value = 0
+  let output = ''
+  let bits = 0
+  for (let i = 0; i < length; i++) {
+    // tslint:disable-next-line:no-bitwise
+    value = (value << 8) | buffer[i]
+    bits += 8
+    while (bits >= 5) {
+      // tslint:disable-next-line:no-bitwise
+      output += nanoAlphabet[(value >>> (bits + offset - 5)) & 31]
+      bits -= 5
+    }
+  }
+  if (bits > 0) {
+    // tslint:disable-next-line:no-bitwise
+    output += nanoAlphabet[(value << (5 - (bits + offset))) & 31]
+  }
+  return output
+}
+
+export function encodeNanoAddr(data: Buffer): string {
+  const hex = data.toString('hex');
+  // tslint:disable-next-line:no-bitwise
+  const length = (hex.length / 2) | 0;
+  const uint8 = new Uint8Array(length);
+  for (let i = 0; i < length; i++) {
+    uint8[i] = parseInt(hex.substr(i * 2, 2), 16);
+  }
+  const address = nanobase32(uint8);
+  const checksumbytes = blake2b(uint8, null, 5).reverse();
+  const checksum = nanobase32(checksumbytes);
+  return 'nano_' + address + checksum
+}
+
+export function decodeNanoAddr(account: string): Buffer {
+  if (
+  ((account.startsWith('nano_1') || account.startsWith('nano_3')) && (account.length === 65))   ||
+  ((account.startsWith('xrb_1') || account.startsWith('xrb_3')) && (account.length === 64))
+  ) {
+    const accountCrop = account.slice(-60);
+    const isValid = /^[13456789abcdefghijkmnopqrstuwxyz]+$/.test(accountCrop);
+    if (isValid) {
+      const input = accountCrop.substring(0, 52);
+      const length = input.length
+      const leftover = (length * 5) % 8
+      const offset = leftover === 0 ? 0 : 8 - leftover
+      let bits = 0
+      let value = 0
+      let index = 0
+      let output = new Uint8Array(Math.ceil(length * 5 / 8))
+      for (let i = 0; i < length; i++) {
+	// tslint:disable-next-line:no-bitwise
+        value = (value << 5) | nanoAlphabet.indexOf(input[i])
+        bits += 5
+        if (bits >= 8) {
+          // tslint:disable-next-line:no-bitwise
+          output[index++] = (value >>> (bits + offset - 8)) & 255
+          bits -= 8
+        }
+      }
+      if (bits > 0) {
+	// tslint:disable-next-line:no-bitwise
+        output[index++] = (value << (bits + offset - 8)) & 255
+      }
+      if (leftover !== 0) {
+        output = output.slice(1)
+      }
+      return Buffer.from(output);
+    } else {
+      throw Error('Illegal characters found');
+    }
+  } else {
+    throw Error('Invalid account');
+  }
+}

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -199,6 +199,13 @@ const vectors: Array<TestVector> = [
     passingVectors: [
       { text: 'cosmos1depk54cuajgkzea6zpgkq36tnjwdzv4afc3d27', hex: '6e436a571cec916167ba105160474b9c9cd132bd' }
     ],
+  },
+  {
+    name: 'NANO',
+    coinType: 44,
+    passingVectors: [
+      { text: 'nano_1qgkdadcbwn65sp95gr144fuc99tm5tn6gx9y8ow9bgaam6r5ixgtx19tw93', hex: '5dd25a16a4f2841e6c71bb00109bb51cfa98f5423ba7f1abc3a5c844c981c3ae' }
+    ],
   }
 ];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { decode as bech32Decode, encode as bech32Encode, fromWords as bech32FromWords, toWords as bech32ToWords } from 'bech32';
 // @ts-ignore
-import { encodeNanoAddr, decodeNanoAddr } from './@types/nano32/index'
-// @ts-ignore
 import { b32decode, b32encode, bs58Decode, bs58Encode, cashaddrDecode, cashaddrEncode, codec as xrpCodec, decodeCheck as decodeEd25519PublicKey, encodeCheck as encodeEd25519PublicKey, eosPublicKey, hex2a, isValid as isValidXemAddress, isValidChecksumAddress as rskIsValidChecksumAddress, ss58Decode, ss58Encode, stripHexPrefix as rskStripHexPrefix, toChecksumAddress as rskToChecksumAddress, ua2hex } from 'crypto-addr-codec';
+// @ts-ignore
+import { decodeNanoAddr, encodeNanoAddr } from './@types/nano32/index';
 
 type EnCoder = (data: Buffer) => string
 type DeCoder = (data: string) => Buffer

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { decode as bech32Decode, encode as bech32Encode, fromWords as bech32FromWords, toWords as bech32ToWords } from 'bech32';
 // @ts-ignore
-import { b32decode, b32encode, bs58Decode, bs58Encode, cashaddrDecode, cashaddrEncode, codec as xrpCodec, decodeCheck as decodeEd25519PublicKey, encodeCheck as encodeEd25519PublicKey, eosPublicKey, hex2a, isValid as isValidXemAddress, isValidChecksumAddress as rskIsValidChecksumAddress, ss58Decode, ss58Encode, stripHexPrefix as rskStripHexPrefix, toChecksumAddress as rskToChecksumAddress, ua2hex } from 'crypto-addr-codec';
-// @ts-ignore
 import { blake2b } from 'blakejs'
+// @ts-ignore
+import { b32decode, b32encode, bs58Decode, bs58Encode, cashaddrDecode, cashaddrEncode, codec as xrpCodec, decodeCheck as decodeEd25519PublicKey, encodeCheck as encodeEd25519PublicKey, eosPublicKey, hex2a, isValid as isValidXemAddress, isValidChecksumAddress as rskIsValidChecksumAddress, ss58Decode, ss58Encode, stripHexPrefix as rskStripHexPrefix, toChecksumAddress as rskToChecksumAddress, ua2hex } from 'crypto-addr-codec';
 
 interface IFormat {
   coinType: number;
@@ -231,15 +231,18 @@ function nanobase32(buffer: Uint8Array): string {
   let value = 0
   let output = ''
   let bits = 0
-  for (var i = 0; i < length; i++) {
+  for (let i = 0; i < length; i++) {
+    // tslint:disable-next-line:no-bitwise
     value = (value << 8) | buffer[i]
     bits += 8
     while (bits >= 5) {
+      // tslint:disable-next-line:no-bitwise
       output += nanoAlphabet[(value >>> (bits + offset - 5)) & 31]
       bits -= 5
     }
   }
   if (bits > 0) {
+    // tslint:disable-next-line:no-bitwise
     output += nanoAlphabet[(value << (5 - (bits + offset))) & 31]
   }
   return output
@@ -247,9 +250,12 @@ function nanobase32(buffer: Uint8Array): string {
 
 function encodeNanoAddr(data: Buffer): string {
   const hex = data.toString('hex');
+  // tslint:disable-next-line:no-bitwise
   const length = (hex.length / 2) | 0;
   const uint8 = new Uint8Array(length);
-  for (let i = 0; i < length; i++) uint8[i] = parseInt(hex.substr(i * 2, 2), 16);
+  for (let i = 0; i < length; i++) {
+    uint8[i] = parseInt(hex.substr(i * 2, 2), 16);
+  }
   const address = nanobase32(uint8);
   const checksumbytes = blake2b(uint8, null, 5).reverse();
   const checksum = nanobase32(checksumbytes);
@@ -258,13 +264,13 @@ function encodeNanoAddr(data: Buffer): string {
 
 function decodeNanoAddr(account: string): Buffer {
   if (
-  ((account.startsWith('nano_1') || account.startsWith('nano_3')) && (account.length == 65))   ||
-  ((account.startsWith('xrb_1') || account.startsWith('xrb_3')) && (account.length == 64))
+  ((account.startsWith('nano_1') || account.startsWith('nano_3')) && (account.length === 65))   ||
+  ((account.startsWith('xrb_1') || account.startsWith('xrb_3')) && (account.length === 64))
   ) {
-    const account_crop = account.slice(-60);
-    const isValid = /^[13456789abcdefghijkmnopqrstuwxyz]+$/.test(account_crop);
+    const accountCrop = account.slice(-60);
+    const isValid = /^[13456789abcdefghijkmnopqrstuwxyz]+$/.test(accountCrop);
     if (isValid) {
-      const input = account_crop.substring(0, 52);
+      const input = accountCrop.substring(0, 52);
       const length = input.length
       const leftover = (length * 5) % 8
       const offset = leftover === 0 ? 0 : 8 - leftover
@@ -272,15 +278,18 @@ function decodeNanoAddr(account: string): Buffer {
       let value = 0
       let index = 0
       let output = new Uint8Array(Math.ceil(length * 5 / 8))
-      for (var i = 0; i < length; i++) {
+      for (let i = 0; i < length; i++) {
+	// tslint:disable-next-line:no-bitwise
         value = (value << 5) | nanoAlphabet.indexOf(input[i])
         bits += 5
         if (bits >= 8) {
+          // tslint:disable-next-line:no-bitwise
           output[index++] = (value >>> (bits + offset - 8)) & 255
           bits -= 8
         }
       }
       if (bits > 0) {
+	// tslint:disable-next-line:no-bitwise
         output[index++] = (value << (bits + offset - 8)) & 255
       }
       if (leftover !== 0) {
@@ -288,10 +297,10 @@ function decodeNanoAddr(account: string): Buffer {
       }
       return Buffer.from(output);
     } else {
-      throw "Illegal characters found.";
+      throw Error('Illegal characters found');
     }
   } else {
-    throw "Invalid account.";
+    throw Error('Invalid account');
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import { decode as bech32Decode, encode as bech32Encode, fromWords as bech32FromWords, toWords as bech32ToWords } from 'bech32';
 // @ts-ignore
 import { b32decode, b32encode, bs58Decode, bs58Encode, cashaddrDecode, cashaddrEncode, codec as xrpCodec, decodeCheck as decodeEd25519PublicKey, encodeCheck as encodeEd25519PublicKey, eosPublicKey, hex2a, isValid as isValidXemAddress, isValidChecksumAddress as rskIsValidChecksumAddress, ss58Decode, ss58Encode, stripHexPrefix as rskStripHexPrefix, toChecksumAddress as rskToChecksumAddress, ua2hex } from 'crypto-addr-codec';
+// @ts-ignore
+import { blake2b } from 'blakejs'
 
 interface IFormat {
   coinType: number;
@@ -220,6 +222,79 @@ function b32decodeXemAddr(data: string): Buffer {
   return b32decode(address)
 }
 
+const nanoAlphabet = '13456789abcdefghijkmnopqrstuwxyz'
+
+function nanobase32(buffer: Uint8Array): string {
+  const length = buffer.length
+  const leftover = (length * 8) % 5
+  const offset = leftover === 0 ? 0 : 5 - leftover
+  let value = 0
+  let output = ''
+  let bits = 0
+  for (var i = 0; i < length; i++) {
+    value = (value << 8) | buffer[i]
+    bits += 8
+    while (bits >= 5) {
+      output += nanoAlphabet[(value >>> (bits + offset - 5)) & 31]
+      bits -= 5
+    }
+  }
+  if (bits > 0) {
+    output += nanoAlphabet[(value << (5 - (bits + offset))) & 31]
+  }
+  return output
+}
+
+function encodeNanoAddr(data: Buffer): string {
+  const hex = data.toString('hex');
+  const length = (hex.length / 2) | 0;
+  const uint8 = new Uint8Array(length);
+  for (let i = 0; i < length; i++) uint8[i] = parseInt(hex.substr(i * 2, 2), 16);
+  const address = nanobase32(uint8);
+  const checksumbytes = blake2b(uint8, null, 5).reverse();
+  const checksum = nanobase32(checksumbytes);
+  return 'nano_' + address + checksum
+}
+
+function decodeNanoAddr(account: string): Buffer {
+  if (
+  ((account.startsWith('nano_1') || account.startsWith('nano_3')) && (account.length == 65))   ||
+  ((account.startsWith('xrb_1') || account.startsWith('xrb_3')) && (account.length == 64))
+  ) {
+    const account_crop = account.slice(-60);
+    const isValid = /^[13456789abcdefghijkmnopqrstuwxyz]+$/.test(account_crop);
+    if (isValid) {
+      const input = account_crop.substring(0, 52);
+      const length = input.length
+      const leftover = (length * 5) % 8
+      const offset = leftover === 0 ? 0 : 8 - leftover
+      let bits = 0
+      let value = 0
+      let index = 0
+      let output = new Uint8Array(Math.ceil(length * 5 / 8))
+      for (var i = 0; i < length; i++) {
+        value = (value << 5) | nanoAlphabet.indexOf(input[i])
+        bits += 5
+        if (bits >= 8) {
+          output[index++] = (value >>> (bits + offset - 8)) & 255
+          bits -= 8
+        }
+      }
+      if (bits > 0) {
+        output[index++] = (value << (bits + offset - 8)) & 255
+      }
+      if (leftover !== 0) {
+        output = output.slice(1)
+      }
+      return Buffer.from(output);
+    } else {
+      throw "Illegal characters found.";
+    }
+  } else {
+    throw "Invalid account.";
+  }
+}
+
 function eosAddrEncoder(data: Buffer): string {
   if (!eosPublicKey.isValid(data)) {
     throw Error('Unrecognised address format');
@@ -318,6 +393,12 @@ const formats: IFormat[] = [
   },
   hexChecksumChain('XDAI', 700),
   bech32Chain('BNB', 714, 'bnb'),
+  {
+    coinType: 44,
+    decoder: decodeNanoAddr,
+    encoder: encodeNanoAddr,
+    name: 'NANO',
+  },
 ];
 
 export const formatsByName: { [key: string]: IFormat } = Object.assign({}, ...formats.map(x => ({ [x.name]: x })));

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { decode as bech32Decode, encode as bech32Encode, fromWords as bech32FromWords, toWords as bech32ToWords } from 'bech32';
 // @ts-ignore
-import { blake2b } from 'blakejs'
+import { encodeNanoAddr, decodeNanoAddr } from './@types/nano32/index'
 // @ts-ignore
 import { b32decode, b32encode, bs58Decode, bs58Encode, cashaddrDecode, cashaddrEncode, codec as xrpCodec, decodeCheck as decodeEd25519PublicKey, encodeCheck as encodeEd25519PublicKey, eosPublicKey, hex2a, isValid as isValidXemAddress, isValidChecksumAddress as rskIsValidChecksumAddress, ss58Decode, ss58Encode, stripHexPrefix as rskStripHexPrefix, toChecksumAddress as rskToChecksumAddress, ua2hex } from 'crypto-addr-codec';
 
@@ -223,88 +223,6 @@ function b32decodeXemAddr(data: string): Buffer {
   }
   const address = data.toString().toUpperCase().replace(/-/g, '');
   return b32decode(address)
-}
-
-const nanoAlphabet = '13456789abcdefghijkmnopqrstuwxyz'
-
-function nanobase32(buffer: Uint8Array): string {
-  const length = buffer.length
-  const leftover = (length * 8) % 5
-  const offset = leftover === 0 ? 0 : 5 - leftover
-  let value = 0
-  let output = ''
-  let bits = 0
-  for (let i = 0; i < length; i++) {
-    // tslint:disable-next-line:no-bitwise
-    value = (value << 8) | buffer[i]
-    bits += 8
-    while (bits >= 5) {
-      // tslint:disable-next-line:no-bitwise
-      output += nanoAlphabet[(value >>> (bits + offset - 5)) & 31]
-      bits -= 5
-    }
-  }
-  if (bits > 0) {
-    // tslint:disable-next-line:no-bitwise
-    output += nanoAlphabet[(value << (5 - (bits + offset))) & 31]
-  }
-  return output
-}
-
-function encodeNanoAddr(data: Buffer): string {
-  const hex = data.toString('hex');
-  // tslint:disable-next-line:no-bitwise
-  const length = (hex.length / 2) | 0;
-  const uint8 = new Uint8Array(length);
-  for (let i = 0; i < length; i++) {
-    uint8[i] = parseInt(hex.substr(i * 2, 2), 16);
-  }
-  const address = nanobase32(uint8);
-  const checksumbytes = blake2b(uint8, null, 5).reverse();
-  const checksum = nanobase32(checksumbytes);
-  return 'nano_' + address + checksum
-}
-
-function decodeNanoAddr(account: string): Buffer {
-  if (
-  ((account.startsWith('nano_1') || account.startsWith('nano_3')) && (account.length === 65))   ||
-  ((account.startsWith('xrb_1') || account.startsWith('xrb_3')) && (account.length === 64))
-  ) {
-    const accountCrop = account.slice(-60);
-    const isValid = /^[13456789abcdefghijkmnopqrstuwxyz]+$/.test(accountCrop);
-    if (isValid) {
-      const input = accountCrop.substring(0, 52);
-      const length = input.length
-      const leftover = (length * 5) % 8
-      const offset = leftover === 0 ? 0 : 8 - leftover
-      let bits = 0
-      let value = 0
-      let index = 0
-      let output = new Uint8Array(Math.ceil(length * 5 / 8))
-      for (let i = 0; i < length; i++) {
-	// tslint:disable-next-line:no-bitwise
-        value = (value << 5) | nanoAlphabet.indexOf(input[i])
-        bits += 5
-        if (bits >= 8) {
-          // tslint:disable-next-line:no-bitwise
-          output[index++] = (value >>> (bits + offset - 8)) & 255
-          bits -= 8
-        }
-      }
-      if (bits > 0) {
-	// tslint:disable-next-line:no-bitwise
-        output[index++] = (value << (bits + offset - 8)) & 255
-      }
-      if (leftover !== 0) {
-        output = output.slice(1)
-      }
-      return Buffer.from(output);
-    } else {
-      throw Error('Illegal characters found');
-    }
-  } else {
-    throw Error('Invalid account');
-  }
 }
 
 function eosAddrEncoder(data: Buffer): string {


### PR DESCRIPTION
Please let me know if there is anything I missed here. 

Nano addresses are base32 hex conversions with a custom alphabet, and a 5 character blake2b checksum hash appended to the end. (the blakejs dep)

I tested this pretty thoroughly locally, the only thing I am not 100% on is error handling so I used throws like other functions. 

NodeJS example: 
```
const { formatsByName, formatsByCoinType } = require('@ensdomains/address-encoder');
const data = formatsByName['NANO'].decoder('nano_1qgkdadcbwn65sp95gr144fuc99tm5tn6gx9y8ow9bgaam6r5ixgtx19tw93');
console.log(data.toString('hex'));
const addr = formatsByCoinType[44].encoder(data);
console.log(addr); 
```