### PR TITLE
Add support for DOT

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -171,6 +171,13 @@ const vectors: Array<TestVector> = [
     ],
   },
   {
+    name: 'DOT',
+    coinType: 354,
+    passingVectors: [
+      { text: '1FRMM8PEiWXYax7rpS6X4XZX1aAAxSWx1CrKTyrVYhV24fg', hex: '0aff6865635ae11013a83835c019d44ec3f865145943f487ae82a8e7bed3a66b' },
+    ],
+  },
+  {
     name: 'KSM',
     coinType: 434,
     passingVectors: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -238,6 +238,10 @@ function ksmAddrEncoder(data: Buffer): string {
   return ss58Encode(Uint8Array.from(data), 2)
 }
 
+function dotAddrEncoder(data: Buffer): string {
+  return ss58Encode(Uint8Array.from(data), 0)
+}
+
 function ksmAddrDecoder(data: string): Buffer {
   return new Buffer(ss58Decode(data))
 }
@@ -295,6 +299,12 @@ const formats: IFormat[] = [
     decoder: bs58Decode,
     encoder: bs58Encode,
     name: 'TRX',
+  },
+  {
+    coinType: 354,
+    decoder: ksmAddrDecoder,
+    encoder: dotAddrEncoder,
+    name: 'DOT'
   },
   {
     coinType: 434,


### PR DESCRIPTION
Adding support for [DOT](https://guide.kusama.network/docs/en/learn-accounts). Decoding is exactly the same as Kusama. Just need to add `0` prefix when encoding.

https://github.com/ensdomains/address-encoder/pull/23#issuecomment-680017719

