### PR TITLE
Add VET support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This library currently supports the following cryptocurrencies and address forma
  - ETC (checksummed-hex)
  - RSK (checksummed-hex)
  - XDAI (checksummed-hex)
+ - VET (checksummed-hex)
  - XRP (base58check-ripple)
  - BCH (base58check and cashAddr; decodes to cashAddr)
  - BNB (bech32)

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -201,6 +201,13 @@ const vectors: Array<TestVector> = [
     ],
   },
   {
+    name: 'VET',
+    coinType: 703,
+    passingVectors: [
+      { text: '0x9760b32C0A515F6C8c4E6B7B89AF8964DDaCB985', hex: '9760b32c0a515f6c8c4e6b7b89af8964ddacb985' },
+    ],
+  },
+  {
     name: 'ATOM',
     coinType: 118,
     passingVectors: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -285,6 +285,7 @@ const formats: IFormat[] = [
   getConfig('DOT', 354, dotAddrEncoder, ksmAddrDecoder),
   getConfig('KSM', 434, ksmAddrEncoder, ksmAddrDecoder),
   hexChecksumChain('XDAI', 700),
+  hexChecksumChain('VET', 703),
   bech32Chain('BNB', 714, 'bnb'),
 ];
 


### PR DESCRIPTION
add support to vechain protocol 
done https://github.com/ensdomains/address-encoder/issues/50


Ref: https://github.com/trustwallet/wallet-core/blob/8d3100f61e36d1e928ed1dea60ff7554bba0db16/tests/VeChain/SignerTests.cp