### PR TITLE
Added ADA and ADA_TEST support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ This library currently supports the following cryptocurrencies and address forma
  - NEM (base32)
  - EOS
  - KSM (ss58)
+ - ADA (bech32)
 
 
 PRs to add additional chains and address types are welcome.

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -206,6 +206,20 @@ const vectors: Array<TestVector> = [
     passingVectors: [
       { text: 'cosmos1depk54cuajgkzea6zpgkq36tnjwdzv4afc3d27', hex: '6e436a571cec916167ba105160474b9c9cd132bd' }
     ],
+  },
+  {
+    name: 'ADA',
+    coinType: 1815,
+    passingVectors: [
+      { text: 'addr1gqtnpvdhqrtpd4g424fcaq7k0ufuzyadt7djygf8qdyzevuph3wczvf2dwyx5u', hex: '401730b1b700d616d51555538e83d67f13c113ad5f9b22212703482cb381bc5d81312a' },
+    ],
+  },
+  {
+    name: 'ADA_TEST',
+    coinType: 1816,
+    passingVectors: [
+      { text: 'addr_test1vqrlltfahghjxl5sy5h5mvfrrlt6me5fqphhwjqvj5jd88cccqcek', hex: '6007ffad3dba2f237e90252f4db1231fd7ade689006f77480c9524d39f'},
+    ],
   }
 ];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -276,6 +276,8 @@ const formats: IFormat[] = [
   hexChecksumChain('ETH', 60),
   hexChecksumChain('ETC', 61),
   bech32Chain('ATOM', 118, 'cosmos'),
+  bech32Chain('ADA', 1815, 'addr'),
+  bech32Chain('ADA_TEST', 1816, 'addr_test'),
   hexChecksumChain('RSK', 137, 30),
   getConfig('XRP', 144, (data) => xrpCodec.encodeChecked(data), (data) => xrpCodec.decodeChecked(data)),
   getConfig('BCH', 145, encodeCashAddr, decodeBitcoinCash),

--- a/src/index.ts
+++ b/src/index.ts
@@ -276,8 +276,6 @@ const formats: IFormat[] = [
   hexChecksumChain('ETH', 60),
   hexChecksumChain('ETC', 61),
   bech32Chain('ATOM', 118, 'cosmos'),
-  bech32Chain('ADA', 1815, 'addr'),
-  bech32Chain('ADA_TEST', 1816, 'addr_test'),
   hexChecksumChain('RSK', 137, 30),
   getConfig('XRP', 144, (data) => xrpCodec.encodeChecked(data), (data) => xrpCodec.decodeChecked(data)),
   getConfig('BCH', 145, encodeCashAddr, decodeBitcoinCash),
@@ -288,6 +286,8 @@ const formats: IFormat[] = [
   getConfig('KSM', 434, ksmAddrEncoder, ksmAddrDecoder),
   hexChecksumChain('XDAI', 700),
   bech32Chain('BNB', 714, 'bnb'),
+  bech32Chain('ADA', 1815, 'addr'),
+  bech32Chain('ADA_TEST', 1816, 'addr_test'),
 ];
 
 export const formatsByName: { [key: string]: IFormat } = Object.assign({}, ...formats.map(x => ({ [x.name]: x })));


### PR DESCRIPTION
## Issue number
https://github.com/ensdomains/ens-app/issues/910

## Reference

- https://github.com/input-output-hk/cardano-addresses/

- https://github.com/cardano-foundation/CIPs/tree/master/CIP5

- https://github.com/input-output-hk/adrestia

- https://github.com/input-output-hk/bech32

## Description

add support for ADA and ADA_TEST

## List of features added/changed
- added support for ADA for mainnet.
-  added support for ADA_TEST for test network.

NOTE: If you are adding new coin address support, please make sure to add a reference link to README so that reviewer can verify.

## How Has This Been Tested?
- NPM Jest Testing Env
- Usage ``` npm test ```

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/15603274/92782778-e0445100-f3c2-11ea-95d8-f58e87997e10.png)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
