### PR TITLE
added support for PPC (Peercoin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,6 @@ This library currently supports the following cryptocurrencies and address forma
  - NEM (base32)
  - EOS
  - KSM (ss58)
-
+ - PPC (base58check P2PKH and P2SH)
 
 PRs to add additional chains and address types are welcome.

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -185,7 +185,7 @@ const vectors: Array<TestVector> = [
       { text: 'DDioZ6gLeKMc5xUCeSXRHZ5U43MH1Tsrmh8T3Gcg9Vxr6DY', hex: '1c86776eda34405584e710a7363650afd1f2b38ef72836317b11ef1303a0ae72' },
       { text: 'EDNfVHuNHrXsVTLMMNbp6Con5zESZJa3fkRc93AgahuMm99', hex: '487ee7e677203b4209af2ffaec0f5068033c870c97fee18b31b4aee524089943' }
     ],
-  },  
+  },
   {
     name: 'BNB',
     coinType: 714,
@@ -205,6 +205,13 @@ const vectors: Array<TestVector> = [
     coinType: 118,
     passingVectors: [
       { text: 'cosmos1depk54cuajgkzea6zpgkq36tnjwdzv4afc3d27', hex: '6e436a571cec916167ba105160474b9c9cd132bd' }
+    ],
+  },
+  {
+    name: 'PPC',
+    coinType: 6,
+    passingVectors: [
+      { text: 'PRL8bojUujzDGA6HRapzprXWFxMyhpS7Za', hex: '76a914b7a1c4349e794ee3484b8f433a7063eb614dfdc788ac' }
     ],
   }
 ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -271,6 +271,7 @@ const formats: IFormat[] = [
   bitcoinChain('LTC', 2, 'ltc', [0x30], [0x32, 0x05]),
   base58Chain('DOGE', 3, [0x1e], [0x16]),
   base58Chain('DASH', 5, [0x4c], [0x10]),
+  base58Chain('PPC', 6, [0x37], [0x75]),
   bitcoinChain('MONA', 22, 'mona', [0x32], [0x37, 0x05]),
   getConfig('XEM', 43, b32encodeXemAddr, b32decodeXemAddr),
   hexChecksumChain('ETH', 60),


### PR DESCRIPTION
Added support for PPC i.e. peercoin for address encoding library

## Reference 

1. https://docs.peercoin.net/#/peercoin-developer-notes
2. https://talk.peercoin.net/t/the-steps-to-base58-encode-a-peercoin-public-key/1685

## Description
Added support for Peercoin for address encoding library using base58check encoding
```
index | hexa | symbol | coin
6 | 0x80000006 | PPC | Peercoin
```

## List of features added/changed

- PPC (base58check P2PKH and P2SH)
- base58Chain('PPC', 6, [0x37], [0x75])

## How Has This Been Tested?

NodeJS, Jest Testing Environment

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/15603274/92953526-7a69cf00-f47f-11ea-8295-f95303074090.png)


## Checklist:
- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
