### PR TITLE
Add support for CELO

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ This library currently supports the following cryptocurrencies and address forma
  - NEM (base32)
  - EOS
  - KSM (ss58)
+ - CELO (checksummed-hex)
 
 
 PRs to add additional chains and address types are welcome.

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -206,6 +206,13 @@ const vectors: Array<TestVector> = [
     passingVectors: [
       { text: 'cosmos1depk54cuajgkzea6zpgkq36tnjwdzv4afc3d27', hex: '6e436a571cec916167ba105160474b9c9cd132bd' }
     ],
+  },
+  {
+    name: 'CELO',
+    coinType: 52752,
+    passingVectors: [
+      { text: '0x67316300f17f063085Ca8bCa4bd3f7a5a3C66275', hex: '67316300f17f063085ca8bca4bd3f7a5a3c66275' },
+    ],
   }
 ];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -286,6 +286,7 @@ const formats: IFormat[] = [
   getConfig('KSM', 434, ksmAddrEncoder, ksmAddrDecoder),
   hexChecksumChain('XDAI', 700),
   bech32Chain('BNB', 714, 'bnb'),
+  hexChecksumChain('CELO', 52752),
 ];
 
 export const formatsByName: { [key: string]: IFormat } = Object.assign({}, ...formats.map(x => ({ [x.name]: x })));


### PR DESCRIPTION
## Issue number

Closes #51

## Description
Add support for CELO addresses in encoding library

### References:
- Celo official docs
  Addresses of Celo are identical to Ethereum addresses.(https://docs.celo.org/developer-guide/overview/integrations/checklist#addresses)
  BIP44 for Celo(https://docs.celo.org/developer-guide/overview/integrations/checklist#key-derivation)

- SLIP-0044: https://github.com/satoshilabs/slips/blob/master/slip-0044.md
  index | hexa | symbol | coin
  -- | -- | -- | --
  52752 | 0x8000ce10 | CELO | Celo

- Ledger Celo app
  https://github.com/LedgerHQ/app-celo-spender/blob/1960403ee3ce798d66acd143a04a7619bc3a30b8/examples/setSelfAddress.py#L45
  https://github.com/celo-org/celo-ledger-spender-app

## List of features added/changed

Added support for Celo. Celo uses same address format for mainnet and testnet.

## How Has This Been Tested?

Test using NPM Jest test environment.
Use `npm test` command.

## Screenshots (if appropriate):
Result of `npm test`
![image](https://user-images.githubusercontent.com/9247907/93507610-df7a6480-f958-11ea-99e7-22c573a8a246.png)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
