### PR TITLE
Add support for QTUM addresses in encoding library

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,5 +55,6 @@ This library currently supports the following cryptocurrencies and address forma
  - SOL (base58check)
  - ADA (bech32)
  - CELO (checksummed-hex)
+ - QTUM (base58check)
 
 PRs to add additional chains and address types are welcome.

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -192,13 +192,6 @@ const vectors: Array<TestVector> = [
     ],
   },
   {
-    name: 'QTUM',
-    coinType: 2301,
-    passingVectors: [
-      { text: 'Qc6iYCZWn4BauKXGYirRG8pMtgdHMk2dzn', hex: '3aa9f8f3b055324f6b2d6bcac328ec2d7e3cd22d8b' },
-    ],
-  },
-  {
     name: 'DOT',
     coinType: 354,
     passingVectors: [
@@ -274,6 +267,13 @@ const vectors: Array<TestVector> = [
     coinType: 6,
     passingVectors: [
       { text: 'PRL8bojUujzDGA6HRapzprXWFxMyhpS7Za', hex: '76a914b7a1c4349e794ee3484b8f433a7063eb614dfdc788ac' }
+    ],
+  },
+  {
+    name: 'QTUM',
+    coinType: 2301,
+    passingVectors: [
+      { text: 'Qc6iYCZWn4BauKXGYirRG8pMtgdHMk2dzn', hex: '3aa9f8f3b055324f6b2d6bcac328ec2d7e3cd22d8b' },
     ],
   }
 ];

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -192,6 +192,13 @@ const vectors: Array<TestVector> = [
     ],
   },
   {
+    name: 'QTUM',
+    coinType: 2301,
+    passingVectors: [
+      { text: 'Qc6iYCZWn4BauKXGYirRG8pMtgdHMk2dzn', hex: '3aa9f8f3b055324f6b2d6bcac328ec2d7e3cd22d8b' },
+    ],
+  },
+  {
     name: 'DOT',
     coinType: 354,
     passingVectors: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -328,6 +328,7 @@ const formats: IFormat[] = [
   getConfig('EOS', 194, eosAddrEncoder, eosAddrDecoder),
   getConfig('TRX', 195, bs58Encode, bs58Decode),
   getConfig('NEO', 239, bs58Encode, bs58Decode),
+  getConfig('QTUM', 2301, bs58Encode, bs58Decode),
   getConfig('DOT', 354, dotAddrEncoder, ksmAddrDecoder),
   getConfig('SOL', 501, bs58Encode, bs58Decode),
   getConfig('KSM', 434, ksmAddrEncoder, ksmAddrDecoder),

--- a/src/index.ts
+++ b/src/index.ts
@@ -328,7 +328,6 @@ const formats: IFormat[] = [
   getConfig('EOS', 194, eosAddrEncoder, eosAddrDecoder),
   getConfig('TRX', 195, bs58Encode, bs58Decode),
   getConfig('NEO', 239, bs58Encode, bs58Decode),
-  getConfig('QTUM', 2301, bs58Encode, bs58Decode),
   getConfig('DOT', 354, dotAddrEncoder, ksmAddrDecoder),
   getConfig('SOL', 501, bs58Encode, bs58Decode),
   getConfig('KSM', 434, ksmAddrEncoder, ksmAddrDecoder),
@@ -342,6 +341,7 @@ const formats: IFormat[] = [
     name: 'XTZ',
   },
   bech32Chain('ADA', 1815, 'addr'),
+  getConfig('QTUM', 2301, bs58Encode, bs58Decode),
   hexChecksumChain('CELO', 52752)
 ];
 


### PR DESCRIPTION
## Issue number
#81 

## Description
QTUM addresses are base58check so used the relevant function that already exists.
ref: https://medium.com/@Qtum/introduction-to-qtum-economics-a-beginners-guide-to-gas-60d2cd7ac98e
"Our platform uses the Base58 binary-to-text mechanism to generate addresses on the blockchain"

## List of features added/changed
- added support for QTUM addresses 

## How Has This Been Tested?
Added a test and ran.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
