### PR TITLE
#79 Add Support For STEEM Addresses In Encoding Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,5 +55,6 @@ This library currently supports the following cryptocurrencies and address forma
  - SOL (base58check)
  - ADA (bech32)
  - CELO (checksummed-hex)
+ - STEEM (base58check)
 
 PRs to add additional chains and address types are welcome.

--- a/package.json
+++ b/package.json
@@ -35,13 +35,16 @@
     "microbundle": "^0.12.0-next.8",
     "prettier": "^1.18.2",
     "ts-jest": "^24.1.0",
+    "ts-node": "^9.0.0",
     "tslint": "^5.20.0",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "^3.8.2"
+    "typescript": "^3.9.7"
   },
   "dependencies": {
     "bech32": "^1.1.3",
+    "bs58": "^4.0.1",
     "crypto-addr-codec": "^0.1.7",
-    "eztz-lib": "^0.1.2"
+    "eztz-lib": "^0.1.2",
+    "sha3": "^2.1.3"
   }
 }

--- a/src/@types/bs58/index.d.ts
+++ b/src/@types/bs58/index.d.ts
@@ -1,0 +1,4 @@
+declare module 'bs58' {
+        export function encode(data: Buffer): string;
+        export function decode(data: string): Buffer;
+}

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -98,6 +98,13 @@ const vectors: Array<TestVector> = [
     ],
   },
   {
+    name: 'STEEM',
+    coinType: 135,
+    passingVectors: [
+      { text: 'STM7vbxtK1WaZqXsiCHPcjVFBewVj8HFRd5Z5XZDpN6Pvb2dZcMqK', hex: '038fe369a7034a850cf314f615be90f3278331f6bd823d3c85d74ada8cddafa1cd'},
+    ],
+  },
+  {
     name: 'RSK',
     coinType: 137,
     passingVectors: [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue number
#79 

## Description
Implement STEEM encoding and decoding function based on the public official library steem-js
refs: https://github.com/steemit/steem-js/blob/c71fb595cc68f57c1e4b564c948b1d326db4fab3/src/auth/ecc/src/key_public.js#L94
and https://github.com/steemit/steem-js/blob/c71fb595cc68f57c1e4b564c948b1d326db4fab3/src/auth/ecc/src/key_public.js#L110

## List of features added/changed
- Added two functions `steemAddressEncoder` and `steemAddressDecoder` + relevant tests + README.
- There is confusion in the code between base58Check and base58 functions. Added `bs58` library (for base58 functions) and renamed `bs58Encode` and `bs58Decode` functions to `bs58CheckEncode` and `bs58CheckDecode`.

NOTE: If you are adding new coin address support, please make sure to add a reference link to README so that reviewer can verify.

## How Has This Been Tested?
Added a test for STEEM addresses

## Screenshots (if appropriate):

## Checklist:
- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
