### PR TITLE
Added support for transparent and shielded ZEC addresses in encoding library

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,5 +56,6 @@ This library currently supports the following cryptocurrencies and address forma
  - ADA (bech32)
  - CELO (checksummed-hex)
  - HBAR
+ - ZEC (base58check Transparent t1, t3, Shielded Sprout zc and Sapling zs)
 
 PRs to add additional chains and address types are welcome.

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -108,6 +108,10 @@ const vectors: Array<TestVector> = [
         hex:
           '169ac47235aa758c7fffaa12726e7c3c11b48e116db5373215dabadbaaa6a6d5cde458230f1e86b26bd34c383e7503e28a195c5f4016f4ed8020b8e642c0b36baf08',
       },
+      {
+        text: 'zs103kawhns6e9xn48fjgumnp0jsprfpym2hs5ful9r26ckdlnuq6ptcf7hgjxa49ugufkxzfkvun2',
+        hex: '7c6dd75e70d64a69d4e99239b985f2804690936abc289e7ca356b166fe7c0682bc27d7448dda9788e26c61',
+      },
     ],
   },
   {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -98,6 +98,13 @@ const vectors: Array<TestVector> = [
     ],
   },
   {
+    name: 'ZEC',
+    coinType: 133,
+    passingVectors: [
+      { text: 't1MgWUwDTu341f2TPmUmDrGQ6DgCtSeTMj2', hex: '1cb829c750f4e855bd1da10c277a9b4cfd02a8dd612a' },
+    ],
+  },
+  {
     name: 'RSK',
     coinType: 137,
     passingVectors: [

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -103,6 +103,11 @@ const vectors: Array<TestVector> = [
     passingVectors: [
       { text: 't1MgWUwDTu341f2TPmUmDrGQ6DgCtSeTMj2', hex: '1cb829c750f4e855bd1da10c277a9b4cfd02a8dd612a' },
       { text: 't3NmsNDvGXMDfEyUbZ114kjG98Mf5mcw1ge', hex: '1cbd2e318bcaced876a2c7004f251b508dd986cb77fc' },
+      {
+        text: 'zcZviziuUB45WMY4jnV5Vmx6ZKDLyXzb12QbnWyDofTqZEbeJZF49vVNi75UgiuzXFytgJ6bJoq22gUsANBS4BjUfFudBMu',
+        hex:
+          '169ac47235aa758c7fffaa12726e7c3c11b48e116db5373215dabadbaaa6a6d5cde458230f1e86b26bd34c383e7503e28a195c5f4016f4ed8020b8e642c0b36baf08',
+      },
     ],
   },
   {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -102,6 +102,7 @@ const vectors: Array<TestVector> = [
     coinType: 133,
     passingVectors: [
       { text: 't1MgWUwDTu341f2TPmUmDrGQ6DgCtSeTMj2', hex: '1cb829c750f4e855bd1da10c277a9b4cfd02a8dd612a' },
+      { text: 't3NmsNDvGXMDfEyUbZ114kjG98Mf5mcw1ge', hex: '1cbd2e318bcaced876a2c7004f251b508dd986cb77fc' },
     ],
   },
   {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { decode as bech32Decode, encode as bech32Encode, fromWords as bech32FromWords, toWords as bech32ToWords } from 'bech32';
 // @ts-ignore
 import { b32decode, b32encode, bs58Decode, bs58Encode, cashaddrDecode, cashaddrEncode, codec as xrpCodec, decodeCheck as decodeEd25519PublicKey, encodeCheck as encodeEd25519PublicKey, eosPublicKey, hex2a, isValid as isValidXemAddress, isValidChecksumAddress as rskIsValidChecksumAddress, ss58Decode, ss58Encode, stripHexPrefix as rskStripHexPrefix, toChecksumAddress as rskToChecksumAddress, ua2hex } from 'crypto-addr-codec';
+import { decoder as zecDecoder, encoder as zecEncoder } from './zcash';
 
 type EnCoder = (data: Buffer) => string
 type DeCoder = (data: string) => Buffer
@@ -338,6 +339,7 @@ function hederaAddressDecoder(data: string): Buffer {
   return buffer;
 }
 
+
 const getConfig = (name: string, coinType: number, encoder: EnCoder, decoder: DeCoder) => {
   return {
     coinType,
@@ -360,7 +362,8 @@ const formats: IFormat[] = [
   bech32Chain('ATOM', 118, 'cosmos'),
   bech32Chain('ZIL', 119, 'zil'),
   hexChecksumChain('RSK', 137, 30),
-  getConfig('XRP', 144, (data) => xrpCodec.encodeChecked(data), (data) => xrpCodec.decodeChecked(data)),
+  getConfig('ZEC', 133, zecEncoder, zecDecoder),
+  getConfig('XRP', 144, data => xrpCodec.encodeChecked(data), data => xrpCodec.decodeChecked(data)),
   getConfig('BCH', 145, encodeCashAddr, decodeBitcoinCash),
   getConfig('XLM', 148, strEncoder, strDecoder),
   getConfig('EOS', 194, eosAddrEncoder, eosAddrDecoder),
@@ -385,7 +388,7 @@ const formats: IFormat[] = [
     encoder: hederaAddressEncoder,
     name: 'HBAR',
   },
-  hexChecksumChain('CELO', 52752)
+  hexChecksumChain('CELO', 52752),
 ];
 
 export const formatsByName: { [key: string]: IFormat } = Object.assign({}, ...formats.map(x => ({ [x.name]: x })));

--- a/src/zcash.ts
+++ b/src/zcash.ts
@@ -1,17 +1,29 @@
 import { bs58Decode, bs58Encode } from 'crypto-addr-codec';
+import {
+  decode as bech32Decode,
+  encode as bech32Encode,
+  fromWords as bech32FromWords,
+  toWords as bech32ToWords,
+} from 'bech32';
 
 const P2PK_VERSION = [0x1c, 0xb8];
 const P2SH_VERSION = [0x1c, 0xbd];
 const SPROUT_VERSION = [0x16, 0x9a];
+const SAPLING_PREFIX = 'zs';
 
 function decoder(data: string): Buffer {
-  const addr = bs58Decode(data);
   if (data.startsWith('t1')) {
+    const addr = bs58Decode(data);
     return Buffer.concat([Buffer.from(P2PK_VERSION), addr.slice(2)]);
   } else if (data.startsWith('t3')) {
+    const addr = bs58Decode(data);
     return Buffer.concat([Buffer.from(P2SH_VERSION), addr.slice(2)]);
-  } else if (data.startsWith('zc') || data.startsWith('zt')) {
+  } else if (data.startsWith('zc')) {
+    const addr = bs58Decode(data);
     return Buffer.concat([Buffer.from(SPROUT_VERSION), addr.slice(2)]);
+  } else if (data.startsWith('zs')) {
+    const { prefix, words } = bech32Decode(data);
+    return Buffer.from(bech32FromWords(words));
   } else {
     throw Error('Unrecognised address format');
   }
@@ -26,7 +38,13 @@ function encoder(data: Buffer): string {
   ) {
     return bs58Encode(data);
   } else {
-    throw Error('Unrecognised address format');
+    try {
+      const words = bech32ToWords(data);
+      return bech32Encode(SAPLING_PREFIX, words);
+    }
+    catch {
+      throw Error('Unrecognised address format');
+    }
   }
 }
 

--- a/src/zcash.ts
+++ b/src/zcash.ts
@@ -1,0 +1,22 @@
+import { bs58Decode, bs58Encode } from 'crypto-addr-codec';
+
+const P2PK_VERSION = [0x1c, 0xb8];
+
+function decoder(data: string): Buffer {
+  if (data.startsWith('t1')) {
+    const addr = bs58Decode(data);
+    return Buffer.concat([Buffer.from(P2PK_VERSION), addr.slice(2)]);
+  }
+  throw Error('Unrecognised address format');
+}
+
+function encoder(data: Buffer): string {
+  const version = data.slice(0, 2);
+  if (Buffer.from(P2PK_VERSION).equals(version)) {
+    return bs58Encode(data);
+  } else {
+    throw Error('Unrecognised address format');
+  }
+}
+
+export { encoder, decoder };

--- a/src/zcash.ts
+++ b/src/zcash.ts
@@ -4,13 +4,13 @@ Section 5.6: https://zips.z.cash/protocol/protocol.pdf
 ZIP-0173: https://zips.z.cash/zip-0173
 */
 
-import { bs58Decode, bs58Encode } from 'crypto-addr-codec';
 import {
   decode as bech32Decode,
   encode as bech32Encode,
   fromWords as bech32FromWords,
   toWords as bech32ToWords,
 } from 'bech32';
+import { bs58Decode, bs58Encode } from 'crypto-addr-codec';
 
 const BASE58_VERSION_PREFIX: { [index: string]: Buffer } = {
   t1: Buffer.from([0x1c, 0xb8]), // P2PK

--- a/src/zcash.ts
+++ b/src/zcash.ts
@@ -1,18 +1,21 @@
 import { bs58Decode, bs58Encode } from 'crypto-addr-codec';
 
 const P2PK_VERSION = [0x1c, 0xb8];
+const P2SH_VERSION = [0x1c, 0xbd];
 
 function decoder(data: string): Buffer {
+  const addr = bs58Decode(data);
   if (data.startsWith('t1')) {
-    const addr = bs58Decode(data);
     return Buffer.concat([Buffer.from(P2PK_VERSION), addr.slice(2)]);
+  } else if (data.startsWith('t3')) {
+    return Buffer.concat([Buffer.from(P2SH_VERSION), addr.slice(2)]);
   }
   throw Error('Unrecognised address format');
 }
 
 function encoder(data: Buffer): string {
   const version = data.slice(0, 2);
-  if (Buffer.from(P2PK_VERSION).equals(version)) {
+  if (Buffer.from(P2PK_VERSION).equals(version) || Buffer.from(P2SH_VERSION).equals(version)) {
     return bs58Encode(data);
   } else {
     throw Error('Unrecognised address format');

--- a/src/zcash.ts
+++ b/src/zcash.ts
@@ -2,6 +2,7 @@ import { bs58Decode, bs58Encode } from 'crypto-addr-codec';
 
 const P2PK_VERSION = [0x1c, 0xb8];
 const P2SH_VERSION = [0x1c, 0xbd];
+const SPROUT_VERSION = [0x16, 0x9a];
 
 function decoder(data: string): Buffer {
   const addr = bs58Decode(data);
@@ -9,13 +10,20 @@ function decoder(data: string): Buffer {
     return Buffer.concat([Buffer.from(P2PK_VERSION), addr.slice(2)]);
   } else if (data.startsWith('t3')) {
     return Buffer.concat([Buffer.from(P2SH_VERSION), addr.slice(2)]);
+  } else if (data.startsWith('zc') || data.startsWith('zt')) {
+    return Buffer.concat([Buffer.from(SPROUT_VERSION), addr.slice(2)]);
+  } else {
+    throw Error('Unrecognised address format');
   }
-  throw Error('Unrecognised address format');
 }
 
 function encoder(data: Buffer): string {
   const version = data.slice(0, 2);
-  if (Buffer.from(P2PK_VERSION).equals(version) || Buffer.from(P2SH_VERSION).equals(version)) {
+  if (
+    Buffer.from(P2PK_VERSION).equals(version) ||
+    Buffer.from(P2SH_VERSION).equals(version) ||
+    Buffer.from(SPROUT_VERSION).equals(version)
+  ) {
     return bs58Encode(data);
   } else {
     throw Error('Unrecognised address format');

--- a/src/zcash.ts
+++ b/src/zcash.ts
@@ -1,3 +1,9 @@
+/*
+Refernces:
+Section 5.6: https://zips.z.cash/protocol/protocol.pdf
+ZIP-0173: https://zips.z.cash/zip-0173
+*/
+
 import { bs58Decode, bs58Encode } from 'crypto-addr-codec';
 import {
   decode as bech32Decode,
@@ -6,43 +12,34 @@ import {
   toWords as bech32ToWords,
 } from 'bech32';
 
-const P2PK_VERSION = [0x1c, 0xb8];
-const P2SH_VERSION = [0x1c, 0xbd];
-const SPROUT_VERSION = [0x16, 0x9a];
-const SAPLING_PREFIX = 'zs';
+const BASE58_VERSION_PREFIX: { [index: string]: Buffer } = {
+  t1: Buffer.from([0x1c, 0xb8]), // P2PK
+  t3: Buffer.from([0x1c, 0xbd]), // P2SH
+  zc: Buffer.from([0x16, 0x9a]), // SPROUT
+};
+
+const SAPLING_PREFIX = 'zs' // SAPLING
 
 function decoder(data: string): Buffer {
-  if (data.startsWith('t1')) {
-    const addr = bs58Decode(data);
-    return Buffer.concat([Buffer.from(P2PK_VERSION), addr.slice(2)]);
-  } else if (data.startsWith('t3')) {
-    const addr = bs58Decode(data);
-    return Buffer.concat([Buffer.from(P2SH_VERSION), addr.slice(2)]);
-  } else if (data.startsWith('zc')) {
-    const addr = bs58Decode(data);
-    return Buffer.concat([Buffer.from(SPROUT_VERSION), addr.slice(2)]);
-  } else if (data.startsWith('zs')) {
+  if (data.startsWith(SAPLING_PREFIX)) {
     const { prefix, words } = bech32Decode(data);
     return Buffer.from(bech32FromWords(words));
+  } else if (Object.keys(BASE58_VERSION_PREFIX).some(prefix => data.startsWith(prefix))) {
+    const addr = bs58Decode(data);
+    return Buffer.from(addr);
   } else {
     throw Error('Unrecognised address format');
   }
 }
 
 function encoder(data: Buffer): string {
-  const version = data.slice(0, 2);
-  if (
-    Buffer.from(P2PK_VERSION).equals(version) ||
-    Buffer.from(P2SH_VERSION).equals(version) ||
-    Buffer.from(SPROUT_VERSION).equals(version)
-  ) {
+  if (Object.values(BASE58_VERSION_PREFIX).some(prefix => prefix.equals(data.slice(0, prefix.length)))) {
     return bs58Encode(data);
   } else {
     try {
       const words = bech32ToWords(data);
       return bech32Encode(SAPLING_PREFIX, words);
-    }
-    catch {
+    } catch {
       throw Error('Unrecognised address format');
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Issue number
<!--- If there is an associated github issues, please specify here -->
#74 

## Description
<!--- Describe your changes in detail -->
Added support for transparent and shielded ZEC addresses in encoding library

## List of features added/changed
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- ZEC base58 and bech32 encoder
- ZEC base58 and bech32 decoder

## Reference
- [Zcash protocol, Section 5.6](https://zips.z.cash/protocol/protocol.pdf)
- [ZIP-0173](https://zips.z.cash/zip-0173)


## How Has This Been Tested?
Test using NPM Jest test environment.
Use `npm test` command.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/13151232/94217787-bbd29380-feef-11ea-9bba-6e9109f4d19e.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
