### PR TITLE
Add Zcash payment addresses support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,5 +59,6 @@ This library currently supports the following cryptocurrencies and address forma
  - QTUM (base58check)
  - HBAR
  - HNS
+ - ZEC (transparent addresses: base58check P2PKH and P2SH, and Sapling shielded payment addresses: bech32; doesn't support Sprout shielded payment addresses)
 
 PRs to add additional chains and address types are welcome.

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -303,6 +303,27 @@ const vectors: Array<TestVector> = [
     coinType: 2301,
     passingVectors: [
       { text: 'Qc6iYCZWn4BauKXGYirRG8pMtgdHMk2dzn', hex: '3aa9f8f3b055324f6b2d6bcac328ec2d7e3cd22d8b' },
+    ]
+  },
+  {
+    name: 'ZEC',
+    coinType: 133,
+    passingVectors: [
+      {
+        // P2PKH Transparent Address
+        text: 't1b2ArRwLq6KbdJFzJVYPxgUVT1d9QuBzTf',
+        hex: '76a914bc18e286d40706de62928155d6167bf30719857888ac'
+      },
+      {
+        // P2SH Transparent Address
+        text: 't3Vz22vK5z2LcKEdg16Yv4FFneEL1zg9ojd',
+        hex: 'a9147d46a730d31f97b1930d3368a967c309bd4d136a87'
+      },
+      {
+        // Sapling Payment Address (shielded address)
+        text: 'zs1wkejr23wqa9ptpvv73ch3wr96lh8gnyx3689skmyttljy4nyfj69eyclukwkxrhr3rrkgxvnur0',
+        hex: '75b321aa2e074a15858cf47178b865d7ee744c868e8e585b645aff2256644cb45c931fe59d630ee388c764'
+      }
     ],
   },
   {


### PR DESCRIPTION
Closes #74 

## Description
### Transparent Addresses:
Zcash Transparent addresses are either P2PKH or P2SH and two bytes are used for version field. On _Mainnet_ the Base58Check encoded addresses start with **`t1`** for P2PKH and **`t3`** for P2SH.

### Sapling Payment Addresses:
Zcash Sapling shielded payment addresses are encoded using Bech32 as described in https://zips.z.cash/zip-0173. On _Mainnet_ the encoded addresses start with **`zs`**.

> Note: There are changes to both `makeBitcoinBase58CheckEncoder` and `makeBitcoinBase58CheckDecoder` for the sake of reusing. This affects how other protocols based on Bitcoin Base58Check are defined. Specifically, the version field is now an array of one byte or more instead of a single byte.~~, similar effort can be done to `makeBitcoinBase58CheckDecoder` however it will require more significant changes to the rest of the library so I would rather wait for reviews and opinions on that decision. There is especially some redundancy when it comes to Base58CheckDecoder and how Zcash two bytes version field is handled.~~

## List of features added/changed
- Add support for Transparent addresses P2PKH or P2SH **`t1`**, and **`t3`** which use Base58Check.
- Add support for Sapling shielded payment addresses **`zs`** using Bech32 without SegWit.
- No support for Sprout shielded payment addresses. Deprecated in Zcash future plans with migration path already available https://zcash.readthedocs.io/en/latest/rtd_pages/sapling_turnstile.html
- The encoded/decoded addresses were verified using a Rust client based on https://github.com/zcash/librustzcash

## How Has This Been Tested?
- First I used `librustzcash` to get the decoded addresses for the tests (https://github.com/zcash/librustzcash).
- Added the test vectors and made sure all tests pass for different types of addresses.

#### Screenshot of running the test suite:
![address-encoder-tests-20200928](https://user-images.githubusercontent.com/462098/94409326-b048cc00-017e-11eb-90ff-7e80659a1f8a.png)


#### Screenshot of running the rust app:
![zec_address_decoder_rust](https://user-images.githubusercontent.com/462098/94295697-4e177d80-ff6a-11ea-92be-f773dcfccc44.png)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My code implements all the required features ~~(not sure if Sprout shielded payment addresses will be required still).~~

## References:
- [Zcash protocol version 2020.1.14](https://github.com/zcash/zips/blob/v2020.1.14/protocol/protocol.pdf) (of special interest sections `5.6.1 Transparent Addresses` and `5.6.4 Sapling Payment Addresses`)
- [ZIP-173 Bech32 Format](https://zips.z.cash/zip-0173) (BIP-173 without SegWit)
- [Sprout deprecation roadmap](https://github.com/zcash/zcash/issues/3788)
- [Zcash Sprout-to-Sapling Migration Guide](https://zcash.readthedocs.io/en/latest/rtd_pages/sapling_turnstile.html)
- [Example of deprecating Sprout shielded payment addresses in a popular wallet](https://github.com/adityapk00/zecwallet-lite/commit/38e3731beff466b049831a84991960e0fb45d7d6)
- [Zcash rust crate](https://github.com/zcash/librustzcash)
