### PR TITLE
Added base58 (nocheck) and DCR support, closes #83

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,5 +59,7 @@ This library currently supports the following cryptocurrencies and address forma
  - QTUM (base58check)
  - HBAR
  - HNS
+ - DCR (base58, no check)
+
 
 PRs to add additional chains and address types are welcome.

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "bech32": "^1.1.3",
-    "crypto-addr-codec": "^0.1.7"
+    "crypto-addr-codec": "^0.1.7",
+    "bs58": "^4.0.1"
   }
 }

--- a/src/@types/bs58/index.d.ts
+++ b/src/@types/bs58/index.d.ts
@@ -1,0 +1,4 @@
+declare module 'bs58' {
+  export function encode(data: any): any;
+  export function decode(data: any): any;
+}

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -62,6 +62,13 @@ const vectors: Array<TestVector> = [
     ],
   },
   {
+    name: 'DCR',
+    coinType: 42,
+    passingVectors: [
+      { text: 'DsnBFk2BdqYP3WEmChpL7TSonhpxUAi8wiA', hex: '073fe8b089c48ba23c60c64c5226d47acfb26565e313934d5d73'},
+    ],
+  },
+  {
     name: 'XEM',
     coinType: 43,
     passingVectors: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,33 @@
-import { decode as bech32Decode, encode as bech32Encode, fromWords as bech32FromWords, toWords as bech32ToWords } from 'bech32';
+import {
+  decode as bech32Decode,
+  encode as bech32Encode,
+  fromWords as bech32FromWords,
+  toWords as bech32ToWords,
+} from 'bech32';
+import { decode as bs58DecodeNoCheck, encode as bs58EncodeNocheck } from 'bs58';
 // @ts-ignore
-import { b32decode, b32encode, bs58Decode, bs58Encode, cashaddrDecode, cashaddrEncode, codec as xrpCodec, decodeCheck as decodeEd25519PublicKey, encodeCheck as encodeEd25519PublicKey, eosPublicKey, hex2a, isValid as isValidXemAddress, isValidChecksumAddress as rskIsValidChecksumAddress, ss58Decode, ss58Encode, stripHexPrefix as rskStripHexPrefix, toChecksumAddress as rskToChecksumAddress, ua2hex } from 'crypto-addr-codec';
+import {
+  b32decode,
+  b32encode,
+  bs58Decode,
+  bs58Encode,
+  cashaddrDecode,
+  cashaddrEncode,
+  codec as xrpCodec,
+  decodeCheck as decodeEd25519PublicKey,
+  encodeCheck as encodeEd25519PublicKey,
+  eosPublicKey,
+  hex2a,
+  isValid as isValidXemAddress,
+  isValidChecksumAddress as rskIsValidChecksumAddress,
+  ss58Decode,
+  ss58Encode,
+  stripHexPrefix as rskStripHexPrefix,
+  toChecksumAddress as rskToChecksumAddress,
+} from 'crypto-addr-codec';
 
-type EnCoder = (data: Buffer) => string
-type DeCoder = (data: string) => Buffer
+type EnCoder = (data: Buffer) => string;
+type DeCoder = (data: string) => Buffer;
 
 interface IFormat {
   coinType: number;
@@ -201,7 +225,7 @@ function makeBech32Decoder(currentPrefix: string) {
       throw Error('Unrecognised address format');
     }
     return Buffer.from(bech32FromWords(words));
-  }
+  };
 }
 
 const bech32Chain = (name: string, coinType: number, prefix: string) => ({
@@ -219,8 +243,11 @@ function b32decodeXemAddr(data: string): Buffer {
   if (!isValidXemAddress(data)) {
     throw Error('Unrecognised address format');
   }
-  const address = data.toString().toUpperCase().replace(/-/g, '');
-  return b32decode(address)
+  const address = data
+    .toString()
+    .toUpperCase()
+    .replace(/-/g, '');
+  return b32decode(address);
 }
 
 function eosAddrEncoder(data: Buffer): string {
@@ -238,42 +265,44 @@ function eosAddrDecoder(data: string): Buffer {
 }
 
 function ksmAddrEncoder(data: Buffer): string {
-  return ss58Encode(Uint8Array.from(data), 2)
+  return ss58Encode(Uint8Array.from(data), 2);
 }
 
 function dotAddrEncoder(data: Buffer): string {
-  return ss58Encode(Uint8Array.from(data), 0)
+  return ss58Encode(Uint8Array.from(data), 0);
 }
 
 function ksmAddrDecoder(data: string): Buffer {
-  return new Buffer(ss58Decode(data))
+  return new Buffer(ss58Decode(data));
 }
 
 function strDecoder(data: string): Buffer {
-  return decodeEd25519PublicKey('ed25519PublicKey', data)
+  return decodeEd25519PublicKey('ed25519PublicKey', data);
 }
 
 function strEncoder(data: Buffer): string {
-  return encodeEd25519PublicKey('ed25519PublicKey', data)
+  return encodeEd25519PublicKey('ed25519PublicKey', data);
 }
 
 // Referenced from the followings
 // https://tezos.stackexchange.com/questions/183/base58-encoding-decoding-of-addresses-in-micheline
 // https://tezos.gitlab.io/api/p2p.html?highlight=contract_id#contract-id-22-bytes-8-bit-tag
 function tezosAddressEncoder(data: Buffer): string {
-  if (data.length !== 22 && data.length !== 21) { throw Error('Unrecognised address format'); }
+  if (data.length !== 22 && data.length !== 21) {
+    throw Error('Unrecognised address format');
+  }
 
   let prefix: Buffer;
   switch (data.readUInt8(0)) {
     case 0x00:
       if (data.readUInt8(1) === 0x00) {
-          prefix = Buffer.from([0x06, 0xa1, 0x9f]); // prefix tz1 equal 06a19f
+        prefix = Buffer.from([0x06, 0xa1, 0x9f]); // prefix tz1 equal 06a19f
       } else if (data.readUInt8(1) === 0x01) {
-          prefix = Buffer.from([0x06, 0xa1, 0xa1]); // prefix tz2 equal 06a1a1
+        prefix = Buffer.from([0x06, 0xa1, 0xa1]); // prefix tz2 equal 06a1a1
       } else if (data.readUInt8(1) === 0x02) {
-          prefix = Buffer.from([0x06, 0xa1, 0xa4]); // prefix tz3 equal 06a1a4
+        prefix = Buffer.from([0x06, 0xa1, 0xa4]); // prefix tz3 equal 06a1a4
       } else {
-          throw Error('Unrecognised address format');
+        throw Error('Unrecognised address format');
       }
       return bs58Encode(Buffer.concat([prefix, data.slice(2)]));
     case 0x01:
@@ -286,14 +315,14 @@ function tezosAddressEncoder(data: Buffer): string {
 
 function tezosAddressDecoder(data: string): Buffer {
   const address = bs58Decode(data).slice(3);
-  switch (data.substring(0,3)) {
-    case "tz1": 
-      return Buffer.concat([Buffer.from([0x00,0x00]), address]);
-    case "tz2":
-      return Buffer.concat([Buffer.from([0x00,0x01]), address]);
-    case "tz3":
-      return Buffer.concat([Buffer.from([0x00,0x02]), address]);
-    case "KT1":
+  switch (data.substring(0, 3)) {
+    case 'tz1':
+      return Buffer.concat([Buffer.from([0x00, 0x00]), address]);
+    case 'tz2':
+      return Buffer.concat([Buffer.from([0x00, 0x01]), address]);
+    case 'tz3':
+      return Buffer.concat([Buffer.from([0x00, 0x02]), address]);
+    case 'KT1':
       return Buffer.concat([Buffer.from([0x01]), address, Buffer.from([0x00])]);
     default:
       throw Error('Unrecognised address format');
@@ -340,12 +369,12 @@ function hederaAddressDecoder(data: string): Buffer {
 
 // Reference:
 // https://github.com/handshake-org/hsd/blob/c85d9b4c743a9e1c9577d840e1bd20dee33473d3/lib/primitives/address.js#L297
-function hnsAddressEncoder(data: Buffer, ): string {
+function hnsAddressEncoder(data: Buffer): string {
   if (data.length !== 20) {
     throw Error('P2WPKH must be 20 bytes');
   }
 
-  const version = 0
+  const version = 0;
   const words = [version].concat(bech32ToWords(data));
   return bech32Encode('hs', words);
 }
@@ -359,18 +388,18 @@ function hnsAddressDecoder(data: string): Buffer {
     throw Error('Unrecognised address format');
   }
 
-  const version = words[0]
+  const version = words[0];
   const hash = bech32FromWords(words.slice(1));
-  
+
   if (version !== 0) {
     throw Error('Bad program version');
   }
 
-  if(hash.length !== 20) {
+  if (hash.length !== 20) {
     throw Error('Witness program hash is the wrong size');
   }
 
-  return Buffer.from(hash)
+  return Buffer.from(hash);
 }
 
 const getConfig = (name: string, coinType: number, encoder: EnCoder, decoder: DeCoder) => {
@@ -379,8 +408,8 @@ const getConfig = (name: string, coinType: number, encoder: EnCoder, decoder: De
     decoder,
     encoder,
     name,
-  }
-}
+  };
+};
 
 const formats: IFormat[] = [
   bitcoinChain('BTC', 0, 'bc', [0x00], [0x05]),
@@ -390,6 +419,7 @@ const formats: IFormat[] = [
   bitcoinBase58Chain('PPC', 6, [0x37], [0x75]),
   getConfig('NMC', 7, bs58Encode, bs58Decode),
   bitcoinChain('MONA', 22, 'mona', [0x32], [0x37, 0x05]),
+  getConfig('DCR', 42, bs58EncodeNocheck, bs58DecodeNoCheck),
   getConfig('XEM', 43, b32encodeXemAddr, b32decodeXemAddr),
   hexChecksumChain('ETH', 60),
   hexChecksumChain('ETC', 61),
@@ -397,7 +427,7 @@ const formats: IFormat[] = [
   bech32Chain('ZIL', 119, 'zil'),
   bech32Chain('EGLD', 120, 'erd'),
   hexChecksumChain('RSK', 137, 30),
-  getConfig('XRP', 144, (data) => xrpCodec.encodeChecked(data), (data) => xrpCodec.decodeChecked(data)),
+  getConfig('XRP', 144, data => xrpCodec.encodeChecked(data), data => xrpCodec.decodeChecked(data)),
   getConfig('BCH', 145, encodeCashAddr, decodeBitcoinCash),
   getConfig('XLM', 148, strEncoder, strDecoder),
   getConfig('EOS', 194, eosAddrEncoder, eosAddrDecoder),

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,8 @@ import {
   fromWords as bech32FromWords,
   toWords as bech32ToWords,
 } from 'bech32';
-import { decode as bs58DecodeNoCheck, encode as bs58EncodeNocheck } from 'bs58';
 import bigInt from 'big-integer';
+import { decode as bs58DecodeNoCheck, encode as bs58EncodeNocheck } from 'bs58';
 // @ts-ignore
 import {
   b32decode,


### PR DESCRIPTION
## Issue number
Closes #83 

## Description
Added base58 (without check) for DCR support
<!--- Describe your changes in detail -->

## List of features added/changed
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Added bs58 library
- Renamed old bs58 functions to bs58Check
- Added DCR encoding

## Reference
- Dacred Dev Doc: [Address](https://devdocs.decred.org/developer-guides/addresses/)

## How Has This Been Tested?
- Used a DCR address and decode it using an online tool to generate base58 format

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/13151232/94347547-1419aa80-0042-11eb-811d-576f327cc238.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
