### PR TITLE
Add support for Ontology ONT address

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,5 +56,6 @@ This library currently supports the following cryptocurrencies and address forma
  - ADA (bech32)
  - CELO (checksummed-hex)
  - HBAR
+ - ONT (basecheck)
 
 PRs to add additional chains and address types are welcome.

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -237,6 +237,15 @@ const vectors: Array<TestVector> = [
     ],
   },
   {
+    name: 'ONT',
+    coinType: 1024,
+    passingVectors: [
+      { text: 'ALvmTSEjNREwcRNJiLcTkxCnsXBfbZEUFK', hex: '3887346ea0b83129ff21f1ef3e6008a80373d1b3' },
+      { text: 'AavjHwiNfkr7xKGHBpNEQYSL5QiKgRjZf1', hex: 'd21728df85b2b457908bd33def8ff493d47f184a' },
+      { text: 'AGmV3oHqzfAs3VFiqmn6cecxCXVNyg6tNh', hex: '0ae542fee226c044dc19b036db7cec939777596f' },
+    ],
+  },
+  {
     name: 'XTZ',
     coinType: 1729,
     passingVectors: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -254,7 +254,15 @@ function ontAddrEncoder(data: Buffer): string {
 }
 
 function ontAddrDecoder(data: string): Buffer {
-  return bs58Decode(data).slice(1)
+  const address = bs58Decode(data)
+
+  switch (address.readUInt8(0)) {
+   case 0x17:
+     return address.slice(1);
+
+    default:
+      throw Error('Unrecognised address format');
+  }
 }
 
 function strDecoder(data: string): Buffer {

--- a/src/index.ts
+++ b/src/index.ts
@@ -249,6 +249,14 @@ function ksmAddrDecoder(data: string): Buffer {
   return new Buffer(ss58Decode(data))
 }
 
+function ontAddrEncoder(data: Buffer): string {
+  return bs58Encode(Buffer.concat([Buffer.from([0x17]), data]))
+}
+
+function ontAddrDecoder(data: string): Buffer {
+  return bs58Decode(data).slice(1)
+}
+
 function strDecoder(data: string): Buffer {
   return decodeEd25519PublicKey('ed25519PublicKey', data)
 }
@@ -372,6 +380,7 @@ const formats: IFormat[] = [
   hexChecksumChain('XDAI', 700),
   hexChecksumChain('VET', 703),
   bech32Chain('BNB', 714, 'bnb'),
+  getConfig('ONT', 1024, ontAddrEncoder, ontAddrDecoder),
   {
     coinType: 1729,
     decoder: tezosAddressDecoder,


### PR DESCRIPTION
Add support for Ontology ONT address

Rebase against current master, and reuse existing code where possible.
instead https://github.com/ensdomains/address-encoder/pull/20