### PR TITLE
Zen Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ This library currently supports the following cryptocurrencies and address forma
  - XRP (base58check-ripple)
  - XTZ (base58check)
  - ZEC (transparent addresses: base58check P2PKH and P2SH, and Sapling shielded payment addresses: bech32; doesn't support Sprout shielded payment addresses)
+ - ZEN (base58 check)
  - ZIL (bech32)
  
 PRs to add additional chains and address types are welcome.

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -171,6 +171,14 @@ const vectors: Array<TestVector> = [
     ],
   },
   {
+    name: 'ZEN',
+    coinType: 121,
+    passingVectors: [
+      { text: 'znc3p7CFNTsz1s6CceskrTxKevQLPoDK4cK', hex: '20897843a3fcc6ab7d02d40946360c070b13cf7b9795' },
+      { text: 'zswRHzwXtwKVmP8ffKKgWz6A7TB97Fuzx7w', hex: '2096b9d286b397a019f3a41ea6495dbce88d753f28a3' },
+    ],
+  },
+  {
     name: 'ZEC',
     coinType: 133,
     passingVectors: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -629,6 +629,34 @@ function nanoAddressDecoder(data: string): Buffer {
   return Buffer.from(decoded).slice(0, -5);
 }
 
+function zenEncoder(data: Buffer): string {
+  if (
+    !data.slice(0, 2).equals(Buffer.from([0x20, 0x89])) && // zn
+    !data.slice(0, 2).equals(Buffer.from([0x1c, 0xb8])) && // t1
+    !data.slice(0, 2).equals(Buffer.from([0x20, 0x96])) && // zs
+    !data.slice(0, 2).equals(Buffer.from([0x1c, 0xbd])) && // t3
+    !data.slice(0, 2).equals(Buffer.from([0x16, 0x9a])) // zc
+  ) {
+    throw Error('Unrecognised address format');
+  }
+
+  return bs58Encode(data);
+}
+
+function zenDecoder(data: string): Buffer {
+  if (
+    !data.startsWith('zn') &&
+    !data.startsWith('zs') &&
+    !data.startsWith('zc') &&
+    !data.startsWith('t1') &&
+    !data.startsWith('t3')
+  ) {
+    throw Error('Unrecognised address format');
+  }
+
+  return bs58Decode(data);
+}
+
 const getConfig = (name: string, coinType: number, encoder: EnCoder, decoder: DeCoder) => {
   return {
     coinType,
@@ -659,6 +687,7 @@ export const formats: IFormat[] = [
   bech32Chain('ATOM', 118, 'cosmos'),
   bech32Chain('ZIL', 119, 'zil'),
   bech32Chain('EGLD', 120, 'erd'),
+  getConfig('ZEN', 121, zenEncoder, zenDecoder),
   zcashChain('ZEC', 133, 'zs', [[0x1c, 0xb8]], [[0x1c, 0xbd]]),
   getConfig('LSK', 134, liskAddressEncoder, liskAddressDecoder),
   getConfig('STEEM', 135, steemAddressEncoder, steemAddressDecoder),


### PR DESCRIPTION
## Issue number
<!--- If there is an associated github issues, please specify here -->
Closes #163

## List of features added/changed
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- ZEN encoder/decoder based on base58check

## Reference
 - [ZEN uses base58check](https://academy.horizen.io/technology/expert/generating-keys-and-addresses/)
- [Chainparams](https://github.com/HorizenOfficial/zen/blob/v2.0.22/src/chainparams.cpp#L110-L124)
```
        // guarantees the first 2 characters, when base58 encoded, are "zn"
        // guarantees the first 2 characters, when base58 encoded, are "t1"
        base58Prefixes[PUBKEY_ADDRESS]     = {0x20,0x89};
        base58Prefixes[PUBKEY_ADDRESS_OLD]     = {0x1C,0xB8};
        // guarantees the first 2 characters, when base58 encoded, are "zs"
        // guarantees the first 2 characters, when base58 encoded, are "t3"
        base58Prefixes[SCRIPT_ADDRESS]     = {0x20,0x96};
        base58Prefixes[SCRIPT_ADDRESS_OLD]     = {0x1C,0xBD};
        // guarantees the first 2 characters, when base58 encoded, are "zc"
        base58Prefixes[ZCPAYMENT_ADDRRESS] = {0x16,0x9A};
```

## How Has This Been Tested?
- [Zen Tests](https://github.com/HorizenOfficial/zen/blob/master/src/test/data/base58_keys_valid.json)
Note: I have added version bytes manually to the hex format because the library adds it inside the [test file](https://github.com/HorizenOfficial/zen/blob/v2.0.22/src/test/base58_tests.cpp#L142-L145).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
