### PR TITLE
feat: Add support for WAX (WAXP) addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This library currently supports the following cryptocurrencies and address forma
  - STEEM (base58+ripemd160-checksum)
  - TRX (base58check)
  - VET (checksummed-hex)
+ - WAXP
  - XDAI (checksummed-hex)
  - XLM (ed25519 public key)
  - XRP (base58check-ripple)

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -272,6 +272,20 @@ const vectors: Array<TestVector> = [
     ],
   },
   {
+    name: 'WAXP',
+    coinType: 196,
+    passingVectors: [
+      {
+        text: 'EOS4yxqE5KYv5XaB2gj6sZTUDiGzKm42KfiRPDCeXWZUsAZZVXk1F',
+        hex: '020c6dca07e4646ac680925d325f53baa66cb713af858b8cf3496d50832c4f6093',
+      },
+      {
+        text: 'EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV',
+        hex: '02c0ded2bc1f1305fb0faac5e6c03ee3a1924234985427b6167ca569d13df435cf',
+      },
+    ],
+  },
+  {
     name: 'NEO',
     coinType: 239,
     passingVectors: [{ text: 'AXaXZjZGA3qhQRTCsyG5uFKr9HeShgVhTF', hex: '17ad5cac596a1ef6c18ac1746dfd304f93964354b5' }],

--- a/src/index.ts
+++ b/src/index.ts
@@ -635,6 +635,7 @@ export const formats: IFormat[] = [
   getConfig('XLM', 148, strEncoder, strDecoder),
   getConfig('EOS', 194, eosAddrEncoder, eosAddrDecoder),
   getConfig('TRX', 195, bs58Encode, bs58Decode),
+  getConfig('WAXP', 196, eosAddrEncoder, eosAddrDecoder),
   getConfig('NEO', 239, bs58Encode, bs58Decode),
   getConfig('ALGO', 283, algoEncode, algoDecode),
   getConfig('DOT', 354, dotAddrEncoder, ksmAddrDecoder),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add support for WAX (WAXP) addresses
## Issue number
#164 
<!--- If there is an associated github issues, please specify here -->

## Description
<!--- Describe your changes in detail -->
Added support for WAXP which doesn't have a cointype, added a cointype while waiting on how to deal with this.
https://coinmarketcap.com/currencies/wax/
https://developer.wax.io/dapps/create-a-wallet/

NOTE: If you are adding new coin address support, please make sure to add a reference link to README so that reviewer can verify.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![Screenshot from 2020-10-07 23-49-51](https://user-images.githubusercontent.com/13077039/95396065-f678fa80-08f7-11eb-95f4-9edf537e027e.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
