### PR TITLE
Add support for Grin (GRIN) addresses in encoding library

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This library currently supports the following cryptocurrencies and address forma
  - EOS
  - ETC (checksummed-hex)
  - ETH (checksummed-hex)
+ - GRIN (base58check)
  - HBAR
  - HIVE (base58+ripemd160-checksum)
  - HNS

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -277,6 +277,11 @@ const vectors: Array<TestVector> = [
     passingVectors: [{ text: 'AXaXZjZGA3qhQRTCsyG5uFKr9HeShgVhTF', hex: '17ad5cac596a1ef6c18ac1746dfd304f93964354b5' }],
   },
   {
+    name: 'GRIN',
+    coinType: 250,
+    passingVectors: [{ text: '1PfJpZsjreyVrqeoAfabrRwwjQyoSQMmHH', hex: '00f8917303bfa8ef24f292e8fa1419b20460ba064d' }],
+  },
+  {
     name: 'ALGO',
     coinType: 283,
     passingVectors: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -462,7 +462,7 @@ function liskAddressDecoder(data: string): Buffer {
 
   return Buffer.from(bigInt(data.slice(0, -1)).toString(16), 'hex');
 }
-  
+
 // Reference:
 // https://github.com/handshake-org/hsd/blob/c85d9b4c743a9e1c9577d840e1bd20dee33473d3/lib/primitives/address.js#L297
 function hnsAddressEncoder(data: Buffer): string {
@@ -636,6 +636,7 @@ export const formats: IFormat[] = [
   getConfig('EOS', 194, eosAddrEncoder, eosAddrDecoder),
   getConfig('TRX', 195, bs58Encode, bs58Decode),
   getConfig('NEO', 239, bs58Encode, bs58Decode),
+  getConfig('GRIN', 250, bs58Encode, bs58Decode),
   getConfig('ALGO', 283, algoEncode, algoDecode),
   getConfig('DOT', 354, dotAddrEncoder, ksmAddrDecoder),
   getConfig('KSM', 434, ksmAddrEncoder, ksmAddrDecoder),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue number
closes #209

## Description
Connect GRIN to used bs58Encode and bs58Decode

## List of features added/changed
Not much coding only specifying GRIN to used bs58Encode and bs58Decode

## How Has This Been Tested?
Add GRIN in the test pool so that decoded address should match it text version

## Checklist:

- [X ] My code follows the code style of this project.
- [ X] My code implements all the required features.
