### PR TITLE
Add support for  MWC address encoding and decoding functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This library currently supports the following cryptocurrencies and address forma
  - KSM (ss58)
  - LTC (base58check P2PHK and P2SH, and bech32 segwit)
  - MONA (base58check P2PKH and P2SH, and bech32 segwit)
+ - MWC (base58check)
  - NEM (base32)
  - NEO (base58check)
  - ONT (base58check)

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -364,6 +364,11 @@ const vectors: Array<TestVector> = [
     ],
   },
   {
+    name: 'MWC',
+    coinType: 1088,
+    passingVectors: [{ text: '1PfJpZsjreyVrqeoAfabrRwwjQyoSQMmHH', hex: '00f8917303bfa8ef24f292e8fa1419b20460ba064d' }],
+  },
+  {
     name: 'XTZ',
     coinType: 1729,
     passingVectors: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -645,6 +645,7 @@ export const formats: IFormat[] = [
   bech32Chain('BNB', 714, 'bnb'),
   getConfig('HIVE', 825, steemAddressEncoder, steemAddressDecoder),
   getConfig('ONT', 1024, ontAddrEncoder, ontAddrDecoder),
+  getConfig('MWC', 1088, bs58Encode, bs58Decode),
   {
     coinType: 1729,
     decoder: tezosAddressDecoder,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue number
closes #208 

## Description
Connect MWC to used bs58Encode and bs58Decode

## List of features added/changed
Not much coding only specifying MWC to used bs58Encode and bs58Decode

## How Has This Been Tested?
Add MWC in the test pool so that decoded address should match it text version

## Checklist:

- [X ] My code follows the code style of this project.
- [ X] My code implements all the required features.
