### PR TITLE
Add Groestlcoin (GRS) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This library currently supports the following cryptocurrencies and address forma
  - EOS
  - ETC (checksummed-hex)
  - ETH (checksummed-hex)
+ - GRS (base58check P2PKH and P2SH, and bech32 segwit)
  - HBAR
  - HIVE (base58+ripemd160-checksum)
  - HNS

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "bech32": "^1.1.3",
     "bs58": "^4.0.1",
+    "bs58grscheck": "^2.1.2",
     "crypto-addr-codec": "^0.1.7",
     "ripemd160": "^2.0.2"
   }

--- a/src/@types/bs58grscheck/index.d.ts
+++ b/src/@types/bs58grscheck/index.d.ts
@@ -1,0 +1,4 @@
+declare module 'bs58grscheck' {
+  export function encode(data: Buffer): string;
+  export function decode(data: string): Buffer;
+}

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -69,6 +69,15 @@ const vectors: Array<TestVector> = [
     ],
   },
   {
+    name: 'GRS',
+    coinType: 17,
+    passingVectors: [
+      { text: 'FeBhpvNkdtxC7K3LEVT8uqskzwC4mFYrhR', hex: '76a91462e907b15cbf27d5425399ebf6f0fb50ebb88f1888ac' },
+      { text: '3Ai1JZ8pdJb2ksieUV8FsxSNVJCpiWuy6m', hex: 'a91462e907b15cbf27d5425399ebf6f0fb50ebb88f1887' },
+      { text: 'grs1q9ks70lf7cz074lnn3p9ffyjfx8h0f3a8nz55sg', hex: '00142da1e7fd3ec09feafe73884a94924931eef4c7a7' },
+    ],
+  },
+  {
     name: 'MONA',
     coinType: 22,
     passingVectors: [


### PR DESCRIPTION
## PR number
Follow up of https://github.com/ensdomains/address-encoder/pull/21

## Description
This PR will add Groestlcoin or GRS support. Groestlcoin is a coin similar to Bitcoin in that it supports segwit, but it differs in that it uses a different hash algorithm for the checksum of addresses.
 
Therefore the package.json was modified to include `bs58grscheck` which is a fork of `bs58check`. Also other additions were made to accommodate the different check for addresses.
 
`makeBase58GrsCheckDecoder` is added to be used instead of `makeBase58CheckDecoder`

## List of features added/changed 
- base58check P2PKH and P2SH, and bech32 segwit for GRS

## How Has This Been Tested?
This has been tested almost a year now.

## Screenshots
![image](https://user-images.githubusercontent.com/11212268/95833747-5c241700-0d3c-11eb-926b-a28637e01674.png)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My code implements all the required features.
