### PR TITLE
Add support for BTM addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This library currently supports the following cryptocurrencies and address forma
  - BSV (base58check)
  - BTC (base58check P2PKH and P2SH, and bech32 segwit)
  - BTG (base58check P2PKH and P2SH, and bech32 segwit)
+ - BTM (bech32 segwit)
  - BTS (base58+ripemd160-checksum)
  - CCA (base58check P2PKH and P2SH)
  - CCXX (base58check P2PKH and P2SH, and bech32 segwit)

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -331,6 +331,14 @@ const vectors: Array<TestVector> = [
     ],
   },
   {
+    name: 'BTM',
+    coinType: 153,
+    passingVectors: [
+      { text: 'bm1qw508d6qejxtdg4y5r3zarvary0c5xw7k23gyyf', hex: '0014751e76e8199196d454941c45d1b3a323f1433bd6' },
+      { text: 'bm1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qk5egtg', hex: '00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262' },
+    ],
+  },
+  {
     name: 'BTG',
     coinType: 156,
     passingVectors: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1036,6 +1036,7 @@ export const formats: IFormat[] = [
   getConfig('XRP', 144, data => xrpCodec.encodeChecked(data), data => xrpCodec.decodeChecked(data)),
   getConfig('BCH', 145, encodeCashAddr, decodeBitcoinCash),
   getConfig('XLM', 148, strEncoder, strDecoder),
+  getConfig('BTM', 153, makeBech32SegwitEncoder('bm'), makeBech32SegwitDecoder('bm')),
   bitcoinChain('BTG', 156, 'btg', [[0x26]], [[0x17]]),
   getConfig('NANO', 165, nanoAddressEncoder, nanoAddressDecoder),
   bitcoinBase58Chain('RVN', 175, [[0x3c]], [[0x7a]]),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue number
<!--- If there is an associated github issues, please specify here -->
Closes #109 

## Description
<!--- Describe your changes in detail -->
Add support for BTM addresses

## Reference to the specification
<!--- Please provide the reference link to specification. Please try to find the reference of the protocol specification , not just reference to a third party library as we cannot tell that also follows the specification -->
- https://github.com/Bytom/bytom/blob/master/common/address.go#L111

## Reference to the test address.
<!--- Please describe where you found the test address, either from the specificiation doc, test code of other repo, blockchain explorer, etc  -->
- https://github.com/Bytom/bytom/blob/210e21c05088be17c81a1ba1b7cbaa088aa81a8c/common/address_test.go#L28
- https://github.com/Bytom/bytom/blob/210e21c05088be17c81a1ba1b7cbaa088aa81a8c/common/address_test.go#L47

<!-- We are very sensitive about the file size bloat so we may not merge if the file size increase more than 10k. Pleae srun "npm run size" and specify the file size before and after the change -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
- [x] I have specified correct coinTypes specified at [Slip 44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
- [x] I have provided the reference link to the specification I implemented.
- [x] I have provided enough explanation about how I provided the test address
