### PR TITLE
Add support for POA addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ This library currently supports the following cryptocurrencies and address forma
  - NRG (checksummed-hex)
  - ONE (bech32)
  - ONT (base58check)
+ - POA (checksummed-hex)
  - PPC (base58check P2PKH and P2SH)
  - QTUM (base58check)
  - RDD (base58check P2PKH and P2SH)

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -383,6 +383,14 @@ const vectors: Array<TestVector> = [
     ],
   },
   {
+    name: 'POA',
+    coinType: 178,
+    passingVectors: [
+      { text: '0xF977814e90dA44bFA03b6295A0616a897441aceC', hex: 'f977814e90da44bfa03b6295a0616a897441acec' },
+      { text: '0xBE0eB53F46cd790Cd13851d5EFf43D12404d33E8', hex: 'be0eb53f46cd790cd13851d5eff43d12404d33e8' },
+    ],
+  },
+  {
     name: 'EOS',
     coinType: 194,
     passingVectors: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1055,6 +1055,7 @@ export const formats: IFormat[] = [
   bitcoinChain('BTG', 156, 'btg', [[0x26]], [[0x17]]),
   getConfig('NANO', 165, nanoAddressEncoder, nanoAddressDecoder),
   bitcoinBase58Chain('RVN', 175, [[0x3c]], [[0x7a]]),
+  hexChecksumChain('POA', 178),
   eosioChain('EOS', 194, 'EOS'),
   getConfig('TRX', 195, bs58Encode, bs58Decode),
   getConfig('BCN', 204, bcnAddressEncoder, bcnAddressDecoder),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue number
<!--- If there is an associated github issues, please specify here -->
Closes #265 

## Description
<!--- Describe your changes in detail -->
Add support for POA addresses

## Reference to the specification
<!--- Please provide the reference link to specification. Please try to find the reference of the protocol specification , not just reference to a third party library as we cannot tell that also follows the specification -->
- [POA Network is based on Ethereum](https://github.com/poanetwork/wiki)
- https://github.com/poanetwork/blockscout/blob/34ad97c9764bd39cbf71229ddb05ae9d8f134d8e/apps/explorer/lib/explorer/chain/hash/address.ex

## Reference to the test address.
<!--- Please describe where you found the test address, either from the specificiation doc, test code of other repo, blockchain explorer, etc  -->
- Test cases are 1st and 2nd from [POA Explorer](https://blockscout.com/poa/core/accounts)

<!-- We are very sensitive about the file size bloat so we may not merge if the file size increase more than 10k. Pleae srun "npm run size" and specify the file size before and after the change -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
- [x] I have specified correct coinTypes specified at [Slip 44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
- [x] I have provided the reference link to the specification I implemented.
- [x] I have provided enough explanation about how I provided the test address
