### PR TITLE
Add FTM Support

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -875,6 +875,13 @@ const vectors: Array<TestVector> = [
     ],
   },
   {
+    name: 'FTM',
+    coinType: 1007,
+    passingVectors: [
+      { text: '0x314159265dD8dbb310642f98f50C066173C1259b', hex: '314159265dd8dbb310642f98f50c066173c1259b' },
+    ],
+  },
+  {
     name: 'ONE',
     coinType: 1023,
     passingVectors: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1483,6 +1483,7 @@ export const formats: IFormat[] = [
   bech32Chain('RUNE', 931, 'thor'),
   bitcoinChain('BCD', 999, 'bcd', [[0x00]], [[0x05]]),
   hexChecksumChain('TT', 1001),
+  hexChecksumChain('FTM', 1007),
   bech32Chain('ONE', 1023, 'one'),
   getConfig('ONT', 1024, ontAddrEncoder, ontAddrDecoder),
   {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue number
<!--- If there is an associated github issues, please specify here -->

## Description
Adding a support for FTM. FTM shares the same address structure as Ethereum addresses 

## Reference to the specification
https://fantom.foundation/fantom-faq/ (Is FTM an ERC20 token?)

## Reference to the test address.
https://ftmscan.com/address/0x314159265dD8dbb310642f98f50C066173C1259b

## List of features added/changed
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- 
- 

NOTE: If you are adding new coin address support, please make sure to add a reference link to README so that reviewer can verify.

## How much has the filesize increased?

No change

## How Has This Been Tested?

Using the ETH Testcase


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
- [x] I have specified correct coinTypes specified at [Slip 44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
- [x] I have provided the reference link to the specification I implemented.
- [x] I have provided enough explanation about how I provided the test address