### PR TITLE
Add Optimistic Ethereum support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ This library currently supports the following cryptocurrencies and address forma
  - MONA (base58check P2PKH and P2SH, and bech32 segwit)
  - NANO (nano-base32)
  - NAS(base58 + sha3-256-checksum)
- - NEAR 
+ - NEAR
  - NEM(XEM) (base32)
  - NEO (base58check)
  - NMC (base58check)
@@ -104,6 +104,7 @@ This library currently supports the following cryptocurrencies and address forma
  - NULS (base58)
  - ONE (bech32)
  - ONT (base58check)
+ - OPT (checksummed-hex)
  - POA (checksummed-hex)
  - PPC (base58check P2PKH and P2SH)
  - QTUM (base58check)
@@ -142,7 +143,7 @@ This library currently supports the following cryptocurrencies and address forma
  - ZEL (transparent addresses: base58check P2PKH and P2SH, and Sapling shielded payment addresses: bech32; doesn't support Sprout shielded payment addresses)
  - ZEN (base58 check)
  - ZIL (bech32)
- 
+
 
 ## Development guide
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -223,9 +223,9 @@ const vectors: Array<TestVector> = [
     name: 'XMR',
     coinType: 128,
     passingVectors: [
-      { 
-        text: '41tQrTUaj2L93qVeWLaaUG3S2PP2rkaRB2woVf23r1tq3fbyCp36LmSWeMGiaLScUk6tB8f4SonDtRozPJq22i46JS1ZmLt', 
-        hex: '1206f6702fffbd0d301f0832b37c53890e89631be265d5060ba0a5e924d51ea60fefb70ae52bcfc5b13ac9958ea0e9ad232b090cc644efdf94548c5638b626ef9a80a25291' 
+      {
+        text: '41tQrTUaj2L93qVeWLaaUG3S2PP2rkaRB2woVf23r1tq3fbyCp36LmSWeMGiaLScUk6tB8f4SonDtRozPJq22i46JS1ZmLt',
+        hex: '1206f6702fffbd0d301f0832b37c53890e89631be265d5060ba0a5e924d51ea60fefb70ae52bcfc5b13ac9958ea0e9ad232b090cc644efdf94548c5638b626ef9a80a25291'
       },
     ],
   },
@@ -433,9 +433,9 @@ const vectors: Array<TestVector> = [
     name: 'BCN',
     coinType: 204,
     passingVectors: [
-      { 
-        text: '21UQFLdH7WvPZEd8HNwXncHtDwFvv4GRqaN3R4cWyuw2TRZxRtRPb7FFTxfcwwQsqYSD2EqhgVCLsGdRdejAoHFHAHJrxxo', 
-        hex: '0606fd971eb1513f86da272c0e64700d64f013286f1bd024c7768bbfc24b36bd9df9f02985759782567ac26311e9637f96b452da1cb5e15c5d6f0c15cdd107bc52' 
+      {
+        text: '21UQFLdH7WvPZEd8HNwXncHtDwFvv4GRqaN3R4cWyuw2TRZxRtRPb7FFTxfcwwQsqYSD2EqhgVCLsGdRdejAoHFHAHJrxxo',
+        hex: '0606fd971eb1513f86da272c0e64700d64f013286f1bd024c7768bbfc24b36bd9df9f02985759782567ac26311e9637f96b452da1cb5e15c5d6f0c15cdd107bc52'
       },
       {
         text: 'bcnZ6VSM78fQNL5js7VnCybbs3ojLbdAD4DfbdJkUqghYWLqXeEgdyo9UyiAZKnB548DK1ofu8wed3jYCPT62zpf2R97SejoT7',
@@ -552,7 +552,7 @@ const vectors: Array<TestVector> = [
   },
   {
     name: 'ABBC',
-    coinType: 367, 
+    coinType: 367,
     passingVectors: [
       { text: 'ABBC5i3zbGsuyexJc6NaHv81yPh2WeaqrtYMMVaEqcYLz9guAAV74A', hex: '026bff3fc4dc3cde1dcb2068bef16624a260c6f0e330addb54f894bce7fa353de6' },
       { text: 'ABBC5MTKdW6dFqEjYqQYMmLohCsALWcBAx2xRapzDTKAtz3XwKJcaf', hex: '023d3a2e33a90f8f5bcbda1ec129ba1eee5e5f2ab6a77d652cbb0517f2b49669e8' },
@@ -566,7 +566,7 @@ const vectors: Array<TestVector> = [
         hex: '393930326331333636323966633633303431366535306434663266656636616666383637656137652e6c6f636b75702e6e656172' },
         { text: 'blah.com',
         hex: '626c61682e636f6d' },
-        { text: '9685af3fe2dc231e5069ccff8ec6950eb961d42ebb9116a8ab9c0d38f9e45249', 
+        { text: '9685af3fe2dc231e5069ccff8ec6950eb961d42ebb9116a8ab9c0d38f9e45249',
         hex: '39363835616633666532646332333165353036396363666638656336393530656239363164343265626239313136613861623963306433386639653435323439'}
     ],
   },
@@ -574,7 +574,7 @@ const vectors: Array<TestVector> = [
     name: 'ETN',
     coinType: 415,
     passingVectors: [
-      { 
+      {
         text: '45Jmf8PnJKziGyrLouJMeBFw2yVyX1QB52sKEQ4S1VSU2NVsaVGPNu4bWKkaHaeZ6tWCepP6iceZk8XhTLzDaEVa72QrtVh',
         hex: '6135cf83f4b3f9f6c52cb0dc0f91245945346c1ece03640b2a3c5eb9acdf650831d0b00f0a1ddfce4b9bf7df1df46dae94ac6229e492c72d03b94e3609159535',
       },
@@ -660,9 +660,9 @@ const vectors: Array<TestVector> = [
     name: 'AR',
     coinType: 472,
     passingVectors: [
-      { 
-        text: 'GRQ7swQO1AMyFgnuAPI7AvGQlW3lzuQuwlJbIpWV7xk', 
-        hex: '19143bb3040ed403321609ee00f23b02f190956de5cee42ec2525b229595ef19' 
+      {
+        text: 'GRQ7swQO1AMyFgnuAPI7AvGQlW3lzuQuwlJbIpWV7xk',
+        hex: '19143bb3040ed403321609ee00f23b02f190956de5cee42ec2525b229595ef19'
       },
     ],
   },
@@ -699,9 +699,9 @@ const vectors: Array<TestVector> = [
     name: 'XHV',
     coinType: 535,
     passingVectors: [
-      { 
-        text: 'hvs1VkXQ7qvBzrCuTofumZ52HNBhriXWP5kWcqZAG2VDXKuLwcCN5YaF2A4wmUXrZMGiz97eT9jXQBPp6vmRyTsk2ttY8z6YRU', 
-        hex: 'f4b24b708551a04541bfc33b74edddf8180bee188a01b7581c66452619634bf0b54e866dc481be8f53d1d99a470080185e01c7760aac8c4b3e2336b6b1c53da731ff047530a5df' 
+      {
+        text: 'hvs1VkXQ7qvBzrCuTofumZ52HNBhriXWP5kWcqZAG2VDXKuLwcCN5YaF2A4wmUXrZMGiz97eT9jXQBPp6vmRyTsk2ttY8z6YRU',
+        hex: 'f4b24b708551a04541bfc33b74edddf8180bee188a01b7581c66452619634bf0b54e866dc481be8f53d1d99a470080185e01c7760aac8c4b3e2336b6b1c53da731ff047530a5df'
       },
     ],
   },
@@ -747,7 +747,7 @@ const vectors: Array<TestVector> = [
     name: 'BDX',
     coinType: 570,
     passingVectors: [
-      { 
+      {
         text: 'bxdBHRJaUhrFjfHLVESP2KQ7j56LVXhgxBCiJB2fdKvuauVSUpxAqVF3gTvEx9fcd4MditoVxumV3VYFyY35S9TK19JAmCMXz',
         hex: 'd101a272642ddf45581910432620975c8a3385df68e1bb3d3cfe4ce1c97b4c5ecab46cca3eca869e100670ba171e59a77b5b8543ecdabc9aaa9f861374856e3e10a8dd024d2d',
     }
@@ -794,10 +794,17 @@ const vectors: Array<TestVector> = [
     name: 'GRIN',
     coinType: 592,
     passingVectors: [
-      { 
+      {
         text: 'grin1k6m6sjpwc047zdhsdj9r77v5nnxm33hx7wxqvw5dhd9vl0d7t4fsaqt0lg',
-        hex: 'b6b7a8482ec3ebe136f06c8a3f79949ccdb8c6e6f38c063a8dbb4acfbdbe5d53' 
+        hex: 'b6b7a8482ec3ebe136f06c8a3f79949ccdb8c6e6f38c063a8dbb4acfbdbe5d53'
       }
+    ],
+  },
+  {
+    name: 'OPT',
+    coinType: 614,
+    passingVectors: [
+      { text: '0x314159265dD8dbb310642f98f50C066173C1259b', hex: '314159265dd8dbb310642f98f50c066173c1259b' },
     ],
   },
   {

--- a/src/index.ts
+++ b/src/index.ts
@@ -236,7 +236,7 @@ function encodeCashAddr(data: Buffer): string {
 function makeCardanoEncoder(hrp: string): (data: Buffer) => string {
   const encodeByron = makeCardanoByronEncoder();
   const encodeBech32 = makeBech32Encoder(hrp, 104);
-  return (data: Buffer) => { 
+  return (data: Buffer) => {
     try {
       return encodeByron(data);
     } catch {
@@ -269,13 +269,13 @@ function makeCardanoByronEncoder() {
     if (!address.startsWith('Ae2') && !address.startsWith('Ddz')) {
       throw Error('Unrecognised address format');
     }
-  
+
     return address;
    };
 }
 
 function makeCardanoByronDecoder() {
-  return (data: string) => { 
+  return (data: string) => {
     const bytes = bs58DecodeNoCheck(data);
     const bytesAb = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
 
@@ -285,10 +285,10 @@ function makeCardanoByronDecoder() {
     if(taggedAddr === undefined) {
       throw Error('Unrecognised address format');
     }
-  
+
     const addrChecksum = cborDecoded[1];
     const calculatedChecksum = crc32(taggedAddr.value);
-  
+
     if(parseInt(calculatedChecksum, 16) !== addrChecksum) {
       throw Error('Unrecognised address format');
     }
@@ -717,7 +717,7 @@ function liskAddressDecoder(data: string): Buffer {
 
   return Buffer.from(bigInt(data.slice(0, -1)).toString(16), 'hex');
 }
-  
+
 function seroAddressEncoder(data: Buffer): string {
   const address =  bs58EncodeNoCheck(data);
 
@@ -736,14 +736,14 @@ function seroAddressDecoder(data: string): Buffer {
 function wanToChecksumAddress(data: string): string {
   const strippedData = rskStripHexPrefix(data);
   const ndata = strippedData.toLowerCase();
-  
+
   const hashed = new Keccak(256).update(Buffer.from(ndata)).digest();
   let  ret = '0x';
   const len = ndata.length;
   let hashByte;
   for(let i = 0; i < len; i++) {
-    hashByte = hashed[Math.floor(i / 2)]; 
-    
+    hashByte = hashed[Math.floor(i / 2)];
+
     if (i % 2 === 0) {
       /* tslint:disable:no-bitwise */
       hashByte = hashByte >> 4;
@@ -774,17 +774,17 @@ function wanChecksummedHexEncoder(data: Buffer): string {
 function wanChecksummedHexDecoder(data: string): Buffer {
   if(isValidChecksumWanAddress(data)) {
     return Buffer.from(rskStripHexPrefix(data), 'hex');
-  
+
   } else {
     throw Error('Invalid address checksum');
-  
+
   }
 
 }
 
 function calcCheckSum(withoutChecksum: Buffer): Buffer {
   const checksum = (new Keccak(256).update(Buffer.from(blake2b(withoutChecksum, null, 32))).digest()).slice(0, 4);
-  return checksum; 
+  return checksum;
 }
 
 function isByteArrayValid(addressBytes: Buffer): boolean {
@@ -811,8 +811,8 @@ function vsysAddressDecoder(data: string): Buffer {
   const bytes = bs58DecodeNoCheck(base58String);
 
   if(!isByteArrayValid(bytes)) {
-    throw new Error('VSYS: Invalid checksum');   
-  } 
+    throw new Error('VSYS: Invalid checksum');
+  }
   return bytes;
 }
 
@@ -822,7 +822,7 @@ function vsysAddressEncoder(data: Buffer): string {
   }
   return bs58EncodeNoCheck(data);
 }
-  
+
 // Reference:
 // https://github.com/handshake-org/hsd/blob/c85d9b4c743a9e1c9577d840e1bd20dee33473d3/lib/primitives/address.js#L297
 function hnsAddressEncoder(data: Buffer): string {
@@ -860,7 +860,7 @@ function hnsAddressDecoder(data: string): Buffer {
 
 function nasAddressEncoder(data: Buffer): string {
   const checksum = (new SHA3(256).update(data).digest()).slice(0, 4);
-  
+
   return bs58EncodeNoCheck(Buffer.concat([data, checksum]));
 }
 
@@ -974,7 +974,7 @@ function ardrCheckSum(codeword: number[]): boolean {
 
       // tslint:disable-next-line:no-bitwise
       t ^= gmult(codeword[pos], gexp[(i * j) % 31]);
-    
+
   }
     // tslint:disable-next-line:no-bitwise
     sum |= t;
@@ -1006,7 +1006,7 @@ function ardrAddressDecoder(data: string): Buffer {
     if (pos >= 0) {
       clean[count++] = pos;
       if (count > 17) {
-        throw Error('Unrecognised address format');    
+        throw Error('Unrecognised address format');
       }
     }
   }
@@ -1014,7 +1014,7 @@ function ardrAddressDecoder(data: string): Buffer {
   for (let i = 0, j = 0; i < count; i++) {
     codeword[cwmap[j++]] = clean[i];
   }
-  
+
   if (!ardrCheckSum(codeword)) {
     throw Error('Unrecognised address format');
   }
@@ -1026,7 +1026,7 @@ function ardrAddressDecoder(data: string): Buffer {
 function ardrAddressEncoder(data: Buffer): string {
   const dataStr = data.toString('hex');
   const arr = [];
-  
+
   for(let i = 0, j = 0; i < dataStr.length; i = i + 2) {
     arr[cwmap[j++]] = 16 * parseInt(dataStr[i], 16) + parseInt(dataStr[i + 1], 16);
   }
@@ -1042,7 +1042,7 @@ function ardrAddressEncoder(data: Buffer): string {
     if(i < 12 && (i + 1) % 4 === 0 || i === 16 ) {
       rtn.push(acc);
       acc = "";
-    } 
+    }
 
   }
   return `ARDOR-${rtn.join("-")}`;
@@ -1199,14 +1199,14 @@ function etnAddressEncoder(data: Buffer): string {
 
 function etnAddressDecoder(data: string): Buffer {
   const buf = xmrAddressDecoder(data);
-  
+
   if(buf[0] !== 18){
     throw Error('Unrecognised address format');
   }
 
   const checksum = buf.slice(65, 69);
   const checksumVerify = (new Keccak(256).update(buf.slice(0, 65)).digest()).slice(0, 4);
-  
+
   if(!checksumVerify.equals(checksum)) {
     throw Error('Invalid checksum');
   }
@@ -1473,6 +1473,7 @@ export const formats: IFormat[] = [
   bitcoinBase58Chain('BPS', 576, [[0x00]], [[0x05]]),
   hexChecksumChain('TFUEL', 589),
   bech32Chain('GRIN', 592, 'grin'),
+  hexChecksumChain('OPT', 614),
   hexChecksumChain('XDAI', 700),
   hexChecksumChain('VET', 703),
   bech32Chain('BNB', 714, 'bnb'),


### PR DESCRIPTION
## Description
Adds support for OPT. Optimistic Ethereum is EVM equivalent and has the same address format as Ethereum.

## Reference to the specification
https://www.optimism.io/faqs

https://github.com/ethereum-optimism/optimistic-specs


## Reference to the test address.
https://optimistic.etherscan.io/address/0x314159265dD8dbb310642f98f50C066173C1259b

## List of features added/changed
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Added support for OPT network, relative to the slip44 update here https://github.com/satoshilabs/slips/pull/1170

## How much has the filesize increased?
It hasn't. Before and after it is 410635

## How Has This Been Tested?
Using the OPT Testcase

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
- [x] I have specified correct coinTypes specified at [Slip 44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
- [x] I have provided the reference link to the specification I implemented.
- [x] I have provided enough explanation about how I provided the test address
