### PR TITLE
Add Litecoin Cash (LCC) Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ This library currently supports the following cryptocurrencies and address forma
  - KAVA (bech32)
  - KMD (base58check)
  - KSM (ss58)
+ - LCC (base58check P2PKH and P2SH, and bech32 segwit)
  - LRG (base58check P2PKH and P2SH)
  - LSK (hex with suffix)
  - LTC (base58check P2PHK and P2SH, and bech32 segwit)

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -408,6 +408,15 @@ const vectors: Array<TestVector> = [
     ],
   },
   {
+    name: 'LCC',
+    coinType: 192,
+    passingVectors: [
+      { text: 'CJkeBGuySxGcdY1wupo7FXT1h8bbv4zFHt', hex: '76a914191b4f0395e2e66c9c1d9ab5e77a3455acf2c67188ac' },
+      { text: 'MV5hqZU1rNDZ4fubL3Jpc7GMDGHmaVtreg', hex: 'a914e8592f26abbbc754209ae58b131d54312a313b5787' },
+      { text: 'lcc1q45yjegxencjtxslypllvyqfz0xk77mdklxzrcr', hex: '0014ad092ca0d99e24b343e40ffec2012279adef6db6' },
+    ],
+  },
+  {
     name: 'EOS',
     coinType: 194,
     passingVectors: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1452,6 +1452,7 @@ export const formats: IFormat[] = [
   getConfig('NANO', 165, nanoAddressEncoder, nanoAddressDecoder),
   bitcoinBase58Chain('RVN', 175, [[0x3c]], [[0x7a]]),
   hexChecksumChain('POA', 178),
+  bitcoinChain('LCC', 192, 'lcc', [[0x1c]], [[0x32], [0x05]]),
   eosioChain('EOS', 194, 'EOS'),
   getConfig('TRX', 195, bs58Encode, bs58Decode),
   getConfig('BCN', 204, bcnAddressEncoder, bcnAddressDecoder),


### PR DESCRIPTION
Add LitecoinCash (LCC) Support: https://litecoinca.sh/

## Description

- Confirm LCC SLIP 44 coinType (192)
- Add LCC entry
- Add LCC tests

## Reference to the specification

LCC uses Bitcoin-style address encoding, and supports P2PKH, P2SH and bech32.

Relevant chain parameter configuration can be found here: https://github.com/litecoincash-project/litecoincash/blob/master/src/chainparams.cpp#L187

## Reference to the test address

We created three test transactions in order to verify correct derivation of P2PKH, P2SH and bech32 addresses.

The transactions used in the tests can be found here on our block explorer:

- P2PKH: https://chainz.cryptoid.info/lcc/tx.dws?23712553.htm
- P2SH: https://chainz.cryptoid.info/lcc/tx.dws?23712552.htm
- bech32: https://chainz.cryptoid.info/lcc/tx.dws?23712551.htm

## How much has the filesize increased?

Minimal lines added to `src/index.ts` and `src/__tests__/index.test.ts`.

Travis CI reports 410311 for Size test.

## How Has This Been Tested?

Raw hex scripts from the above P2PKH, P2SH and bech32 transactions, with corresponding LCC addresses (as checked in-wallet with `decoderawtransaction` RPC), have been added to `src/__tests__/index.test.ts`.

Travis CI indicates passing tests for each of these decodes.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
- [x] I have specified correct coinTypes specified at [Slip 44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
- [x] I have provided the reference link to the specification I implemented.
- [x] I have provided enough explanation about how I provided the test address

Many thanks for your attention.