### PR TITLE
Add BSC, MATIC, and ARB1

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This library currently supports the following cryptocurrencies and address forma
  - AION (hex)
  - ALGO (checksummed-base32)
  - AR (base64url)
+ - ARB1 (checksummed-hex)
  - ARDR
  - ARK (base58check)
  - ATOM (bech32)
@@ -45,6 +46,7 @@ This library currently supports the following cryptocurrencies and address forma
  - BDX (base58xmr)
  - BNB (bech32)
  - BPS (base58check P2PKH and P2SH)
+ - BSC (checksummed-hex)
  - BSV (base58check)
  - BTC (base58check P2PKH and P2SH, and bech32 segwit)
  - BTG (base58check P2PKH and P2SH, and bech32 segwit)
@@ -93,6 +95,7 @@ This library currently supports the following cryptocurrencies and address forma
  - LSK (hex with suffix)
  - LTC (base58check P2PHK and P2SH, and bech32 segwit)
  - LUNA (bech32)
+ - MATIC (checksummed-hex)
  - MONA (base58check P2PKH and P2SH, and bech32 segwit)
  - NANO (nano-base32)
  - NAS(base58 + sha3-256-checksum)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Text-format addresses are decoded into their native binary representations, and 
 
 This library was written for use with [EIP 2304](https://eips.ethereum.org/EIPS/eip-2304), but may be useful for anyone looking for a general purpose cryptocurrency address codec.
 
+EVM compatible chains are either specified using SLIP44 coinType or `0x800000000 | chainId` where 0x800000000 is msb (most significant bit) reserved at SLIP44 and no coin types exist in that range. This is to avoid number colision with th existing coin types.
+
+For example, cointype of ARB1 is 2147441487(`0x80000000 | 42161`).
+
 ## Installation
 
 ### Using NPM

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -7,6 +7,8 @@ interface TestVector {
   passingVectors: Array<{ text: string; hex: string; canonical?: string; }>;
 }
 
+const MAX_SLIP44_NUMBER = 2415919103 // 0x08fffffff
+
 // Ordered by coinType
 const vectors: Array<TestVector> = [
   {
@@ -1120,6 +1122,27 @@ const vectors: Array<TestVector> = [
       { text: '3PAP3wkgbGjdd1FuBLn9ajXvo6edBMCa115', hex: '01575cb3839cef68f8b5650461fe707311e2919c73b945cf1edc'},
     ],
   },
+  { 
+    name: 'BSC',
+    coinType: MAX_SLIP44_NUMBER + 519,
+    passingVectors: [
+      { text: '0x314159265dD8dbb310642f98f50C066173C1259b', hex: '314159265dd8dbb310642f98f50c066173c1259b' },
+    ],
+  },
+  { 
+    name: 'MATIC',
+    coinType: MAX_SLIP44_NUMBER + 969,
+    passingVectors: [
+      { text: '0x314159265dD8dbb310642f98f50C066173C1259b', hex: '314159265dd8dbb310642f98f50c066173c1259b' },
+    ],
+  },
+  { 
+    name: 'ARB1',
+    coinType: MAX_SLIP44_NUMBER + 42161,
+    passingVectors: [
+      { text: '0x314159265dD8dbb310642f98f50C066173C1259b', hex: '314159265dd8dbb310642f98f50c066173c1259b' },
+    ],
+  } 
 ];
 
 var lastCointype = -1;

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -7,7 +7,6 @@ interface TestVector {
   passingVectors: Array<{ text: string; hex: string; canonical?: string; }>;
 }
 
-
 // Ordered by coinType
 const vectors: Array<TestVector> = [
   {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -696,6 +696,13 @@ const vectors: Array<TestVector> = [
     ],
   },
   {
+    name: 'BSC',
+    coinType: 519,
+    passingVectors: [
+      { text: '0x314159265dD8dbb310642f98f50C066173C1259b', hex: '314159265dd8dbb310642f98f50c066173c1259b' },
+    ],
+  },
+  {
     name: 'XHV',
     coinType: 535,
     passingVectors: [
@@ -864,6 +871,13 @@ const vectors: Array<TestVector> = [
     passingVectors: [
       { text: 'thor1kljxxccrheghavaw97u78le6yy3sdj7h696nl4', hex: 'b7e4636303be517eb3ae2fb9e3ff3a212306cbd7' },
       { text: 'thor1yv0mrrygnjs03zsrwrgqz4sa36evfw2a049l5p', hex: '231fb18c889ca0f88a0370d001561d8eb2c4b95d' },
+    ],
+  },
+  {
+    name: 'MATIC',
+    coinType: 966,
+    passingVectors: [
+      { text: '0x314159265dD8dbb310642f98f50C066173C1259b', hex: '314159265dd8dbb310642f98f50c066173c1259b' },
     ],
   },
   {
@@ -1124,20 +1138,6 @@ const vectors: Array<TestVector> = [
   { 
     name: 'ARB1',
     coinType: convertEVMChainIdToCoinType(42161),
-    passingVectors: [
-      { text: '0x314159265dD8dbb310642f98f50C066173C1259b', hex: '314159265dd8dbb310642f98f50c066173c1259b' },
-    ],
-  },
-  { 
-    name: 'MATIC',
-    coinType: convertEVMChainIdToCoinType(137),
-    passingVectors: [
-      { text: '0x314159265dD8dbb310642f98f50C066173C1259b', hex: '314159265dd8dbb310642f98f50c066173c1259b' },
-    ],
-  },
-  { 
-    name: 'BSC',
-    coinType: convertEVMChainIdToCoinType(56),
     passingVectors: [
       { text: '0x314159265dD8dbb310642f98f50C066173C1259b', hex: '314159265dd8dbb310642f98f50c066173c1259b' },
     ],

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { IFormat, formats, formatsByName, formatsByCoinType } from '../index';
+import { IFormat, formats, formatsByName, formatsByCoinType, convertEVMChainIdToCoinType } from '../index';
 
 interface TestVector {
   name: string;
@@ -7,7 +7,6 @@ interface TestVector {
   passingVectors: Array<{ text: string; hex: string; canonical?: string; }>;
 }
 
-const MAX_SLIP44_NUMBER = 2415919103 // 0x08fffffff
 
 // Ordered by coinType
 const vectors: Array<TestVector> = [
@@ -1122,27 +1121,28 @@ const vectors: Array<TestVector> = [
       { text: '3PAP3wkgbGjdd1FuBLn9ajXvo6edBMCa115', hex: '01575cb3839cef68f8b5650461fe707311e2919c73b945cf1edc'},
     ],
   },
+  // EVM chainIds have to be placed in descending order
   { 
-    name: 'BSC',
-    coinType: MAX_SLIP44_NUMBER + 519,
+    name: 'ARB1',
+    coinType: convertEVMChainIdToCoinType(42161),
     passingVectors: [
       { text: '0x314159265dD8dbb310642f98f50C066173C1259b', hex: '314159265dd8dbb310642f98f50c066173c1259b' },
     ],
   },
   { 
     name: 'MATIC',
-    coinType: MAX_SLIP44_NUMBER + 969,
+    coinType: convertEVMChainIdToCoinType(137),
     passingVectors: [
       { text: '0x314159265dD8dbb310642f98f50C066173C1259b', hex: '314159265dd8dbb310642f98f50c066173c1259b' },
     ],
   },
   { 
-    name: 'ARB1',
-    coinType: MAX_SLIP44_NUMBER + 42161,
+    name: 'BSC',
+    coinType: convertEVMChainIdToCoinType(56),
     passingVectors: [
       { text: '0x314159265dD8dbb310642f98f50C066173C1259b', hex: '314159265dd8dbb310642f98f50c066173c1259b' },
     ],
-  } 
+  }
 ];
 
 var lastCointype = -1;

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ import { ChainID, isValidAddress } from './flow/index';
 import { groestl_2 }  from './groestl-hash-js/index';
 import { xmrAddressDecoder, xmrAddressEncoder } from './monero/xmr-base58';
 import { nimqDecoder, nimqEncoder } from './nimq';
+const MAX_SLIP44_NUMBER = 2415919103 // 0x08fffffff
 
 type EnCoder = (data: Buffer) => string;
 type DeCoder = (data: string) => Buffer;
@@ -483,6 +484,13 @@ const hexChecksumChain = (name: string, coinType: number, chainId?: number) => (
   coinType,
   decoder: makeChecksummedHexDecoder(chainId),
   encoder: makeChecksummedHexEncoder(chainId),
+  name,
+});
+
+const evmChain = (name: string, coinType: number) => ({
+  coinType: coinType + MAX_SLIP44_NUMBER,
+  decoder: makeChecksummedHexDecoder(),
+  encoder: makeChecksummedHexEncoder(),
   name,
 });
 
@@ -1539,6 +1547,9 @@ export const formats: IFormat[] = [
   bitcoinBase58Chain('WICC', 99999, [[0x49]], [[0x33]]),
   getConfig('WAN', 5718350, wanChecksummedHexEncoder, wanChecksummedHexDecoder),
   getConfig('WAVES', 5741564, bs58EncodeNoCheck, wavesAddressDecoder),
+  evmChain('BSC', 519),
+  evmChain('MATIC', 969),
+  evmChain('ARB1', 42161)
 ];
 
 export const formatsByName: { [key: string]: IFormat } = Object.assign({}, ...formats.map(x => ({ [x.name]: x })));

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ import { ChainID, isValidAddress } from './flow/index';
 import { groestl_2 }  from './groestl-hash-js/index';
 import { xmrAddressDecoder, xmrAddressEncoder } from './monero/xmr-base58';
 import { nimqDecoder, nimqEncoder } from './nimq';
-const MAX_SLIP44_NUMBER = 2415919103 // 0x08fffffff
+const SLIP44_MSB = 0x80000000
 
 type EnCoder = (data: Buffer) => string;
 type DeCoder = (data: string) => Buffer;
@@ -487,8 +487,12 @@ const hexChecksumChain = (name: string, coinType: number, chainId?: number) => (
   name,
 });
 
+export const convertEVMChainIdToCoinType = (chainId: number) =>{
+  return Math.abs(SLIP44_MSB | chainId)
+}
+
 const evmChain = (name: string, coinType: number) => ({
-  coinType: coinType + MAX_SLIP44_NUMBER,
+  coinType: convertEVMChainIdToCoinType(coinType),
   decoder: makeChecksummedHexDecoder(),
   encoder: makeChecksummedHexEncoder(),
   name,
@@ -1547,9 +1551,10 @@ export const formats: IFormat[] = [
   bitcoinBase58Chain('WICC', 99999, [[0x49]], [[0x33]]),
   getConfig('WAN', 5718350, wanChecksummedHexEncoder, wanChecksummedHexDecoder),
   getConfig('WAVES', 5741564, bs58EncodeNoCheck, wavesAddressDecoder),
-  evmChain('BSC', 519),
-  evmChain('MATIC', 969),
-  evmChain('ARB1', 42161)
+  // EVM chainIds have to be placed in descending order
+  evmChain('ARB1', 42161),
+  evmChain('MATIC', 137),
+  evmChain('BSC', 56)
 ];
 
 export const formatsByName: { [key: string]: IFormat } = Object.assign({}, ...formats.map(x => ({ [x.name]: x })));

--- a/src/index.ts
+++ b/src/index.ts
@@ -1493,6 +1493,7 @@ export const formats: IFormat[] = [
   bitcoinBase58Chain('CCA', 489, [[0x0b]], [[0x05]]),
   hexChecksumChain('THETA', 500),
   getConfig('SOL', 501, bs58EncodeNoCheck, bs58DecodeNoCheck),
+  hexChecksumChain('BSC', 519),
   getConfig('XHV', 535, xmrAddressEncoder, xmrAddressDecoder),
   getConfig('FLOW', 539, flowEncode, flowDecode),
   bech32Chain('IRIS', 566, 'iaa'),
@@ -1514,6 +1515,7 @@ export const formats: IFormat[] = [
   hexChecksumChain('TOMO', 889),
   getConfig('HNT', 904, hntAddresEncoder, hntAddressDecoder),
   bech32Chain('RUNE', 931, 'thor'),
+  hexChecksumChain('MATIC', 966),
   bitcoinChain('BCD', 999, 'bcd', [[0x00]], [[0x05]]),
   hexChecksumChain('TT', 1001),
   hexChecksumChain('FTM', 1007),
@@ -1552,9 +1554,7 @@ export const formats: IFormat[] = [
   getConfig('WAN', 5718350, wanChecksummedHexEncoder, wanChecksummedHexDecoder),
   getConfig('WAVES', 5741564, bs58EncodeNoCheck, wavesAddressDecoder),
   // EVM chainIds have to be placed in descending order
-  evmChain('ARB1', 42161),
-  evmChain('MATIC', 137),
-  evmChain('BSC', 56)
+  evmChain('ARB1', 42161)
 ];
 
 export const formatsByName: { [key: string]: IFormat } = Object.assign({}, ...formats.map(x => ({ [x.name]: x })));

--- a/src/index.ts
+++ b/src/index.ts
@@ -487,6 +487,7 @@ const hexChecksumChain = (name: string, coinType: number, chainId?: number) => (
   name,
 });
 
+/* tslint:disable:no-bitwise */
 export const convertEVMChainIdToCoinType = (chainId: number) =>{
   return Math.abs(SLIP44_MSB | chainId)
 }


### PR DESCRIPTION
For EVM chain, we will use the convention of MAX_SLIP44_NUMBER + ChainId