### PR TITLE
Add BSC, MATIC, ARB1 all using chainId

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Text-format addresses are decoded into their native binary representations, and 
 
 This library was written for use with [EIP 2304](https://eips.ethereum.org/EIPS/eip-2304), but may be useful for anyone looking for a general purpose cryptocurrency address codec.
 
+EVM compatible chains are either specified using SLIP44 coinType or `0x800000000 | chainId` where 0x800000000 is msb (most significant bit) reserved at SLIP44 and no coin types exist in that range. This is to avoid number colision with th existing coin types.
+
+For example, cointype of ARB1 is 2147441487(`0x80000000 | 42161`).
+
 ## Installation
 
 ### Using NPM
@@ -35,6 +39,7 @@ This library currently supports the following cryptocurrencies and address forma
  - AION (hex)
  - ALGO (checksummed-base32)
  - AR (base64url)
+ - ARB1 (checksummed-hex)
  - ARDR
  - ARK (base58check)
  - ATOM (bech32)
@@ -45,6 +50,7 @@ This library currently supports the following cryptocurrencies and address forma
  - BDX (base58xmr)
  - BNB (bech32)
  - BPS (base58check P2PKH and P2SH)
+ - BSC (checksummed-hex)
  - BSV (base58check)
  - BTC (base58check P2PKH and P2SH, and bech32 segwit)
  - BTG (base58check P2PKH and P2SH, and bech32 segwit)
@@ -94,6 +100,7 @@ This library currently supports the following cryptocurrencies and address forma
  - LSK (hex with suffix)
  - LTC (base58check P2PHK and P2SH, and bech32 segwit)
  - LUNA (bech32)
+ - MATIC (checksummed-hex)
  - MONA (base58check P2PKH and P2SH, and bech32 segwit)
  - NANO (nano-base32)
  - NAS(base58 + sha3-256-checksum)
@@ -176,4 +183,3 @@ This library will be used in many mobile wallets where size bloat impacts the pe
 ## Validate address format, not just encode/decode
 
 Some specifications simply use base58 encoding without specific checksum. However, if there are any extra address format (such as address prefix or address length) exists, please also add that check so that we can prevent users from adding wrong coin address.
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ensdomains/address-encoder",
-  "version": "0.2.12",
+  "version": "0.2.14",
   "description": "Encodes and decodes address formats for various cryptocurrencies",
   "source": "src/index.ts",
   "main": "lib/index.js",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,11 +1,12 @@
 import fs from 'fs';
-import { IFormat, formats, formatsByName, formatsByCoinType } from '../index';
+import { IFormat, formats, formatsByName, formatsByCoinType, convertEVMChainIdToCoinType } from '../index';
 
 interface TestVector {
   name: string;
   coinType: number;
   passingVectors: Array<{ text: string; hex: string; canonical?: string; }>;
 }
+
 
 // Ordered by coinType
 const vectors: Array<TestVector> = [
@@ -1129,6 +1130,28 @@ const vectors: Array<TestVector> = [
       { text: '3PAP3wkgbGjdd1FuBLn9ajXvo6edBMCa115', hex: '01575cb3839cef68f8b5650461fe707311e2919c73b945cf1edc'},
     ],
   },
+  // EVM chainIds
+  {
+    name: 'BSC',
+    coinType: convertEVMChainIdToCoinType(56),
+    passingVectors: [
+      { text: '0x314159265dD8dbb310642f98f50C066173C1259b', hex: '314159265dd8dbb310642f98f50c066173c1259b' },
+    ],
+  },
+  {
+    name: 'MATIC',
+    coinType: convertEVMChainIdToCoinType(137),
+    passingVectors: [
+      { text: '0x314159265dD8dbb310642f98f50C066173C1259b', hex: '314159265dd8dbb310642f98f50c066173c1259b' },
+    ],
+  },
+  {
+    name: 'ARB1',
+    coinType: convertEVMChainIdToCoinType(42161),
+    passingVectors: [
+      { text: '0x314159265dD8dbb310642f98f50C066173C1259b', hex: '314159265dd8dbb310642f98f50c066173c1259b' },
+    ],
+  }
 ];
 
 var lastCointype = -1;

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ import { ChainID, isValidAddress } from './flow/index';
 import { groestl_2 }  from './groestl-hash-js/index';
 import { xmrAddressDecoder, xmrAddressEncoder } from './monero/xmr-base58';
 import { nimqDecoder, nimqEncoder } from './nimq';
-
+const SLIP44_MSB = 0x80000000
 type EnCoder = (data: Buffer) => string;
 type DeCoder = (data: string) => Buffer;
 
@@ -483,6 +483,18 @@ const hexChecksumChain = (name: string, coinType: number, chainId?: number) => (
   coinType,
   decoder: makeChecksummedHexDecoder(chainId),
   encoder: makeChecksummedHexEncoder(chainId),
+  name,
+});
+
+/* tslint:disable:no-bitwise */
+export const convertEVMChainIdToCoinType = (chainId: number) =>{
+  return  (SLIP44_MSB | chainId) >>> 0
+}
+
+const evmChain = (name: string, coinType: number) => ({
+  coinType: convertEVMChainIdToCoinType(coinType),
+  decoder: makeChecksummedHexDecoder(),
+  encoder: makeChecksummedHexEncoder(),
   name,
 });
 
@@ -1540,6 +1552,10 @@ export const formats: IFormat[] = [
   bitcoinBase58Chain('WICC', 99999, [[0x49]], [[0x33]]),
   getConfig('WAN', 5718350, wanChecksummedHexEncoder, wanChecksummedHexDecoder),
   getConfig('WAVES', 5741564, bs58EncodeNoCheck, wavesAddressDecoder),
+  // EVM chainIds
+  evmChain('BSC', 56),
+  evmChain('MATIC', 137),
+  evmChain('ARB1', 42161)
 ];
 
 export const formatsByName: { [key: string]: IFormat } = Object.assign({}, ...formats.map(x => ({ [x.name]: x })));


### PR DESCRIPTION

## Changes

- Fix `convertEVMChainIdToCoinType` logic.
- In addition to ARB1, add back MATIC and BSC using convertEVMChainIdToCoinType (not using SLIP44 cointype)

## Dependencies.

Once this change is merged, the following should happen in the order listed.

- announce the new chainId support [on blog ](https://medium.com/the-ethereum-name-service/how-to-support-evm-compatible-chains-8ebc0de84e3b) with the upcoming breaking changes
- https://github.com/ensdomains/address-encoder/issues/319
- https://github.com/ensdomains/address-encoder/issues/318
- Ask dapps/wallets to change old cointype
- Add other EVM compatible chains (eg: Loopring, boba?) 

## NOTE

The following chains are EVM compatible chains but they support multiple address formats.

- NEAR (it takes both hex and string as their own name service)
- AVAX ([only C-chain supports hex checksum with C- prefix.](https://support.avax.network/en/articles/4596397-what-is-an-address))
- HARMONY ([hex checksum and bech32](https://docs.openswap.one/guide/wallets/harmony-one-coins))

We could either keep them out of scope, or add separate entities (AVAX, AVAXP, [AVAXC](https://github.com/satoshilabs/slips/pull/1202/files), etc) for a single chain

## NOTE 2

Some of layer 2s like zksync, starkware have their own address format so they are out of scope.