### PR TITLE
add nodl support

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ This library currently supports the following cryptocurrencies and address forma
  - NEM(XEM) (base32)
  - NEO (base58check)
  - NMC (base58check)
+ - NODL (ss58)
  - NRG (checksummed-hex)
  - NULS (base58)
  - ONE (bech32)

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -885,6 +885,13 @@ const vectors: Array<TestVector> = [
     ],
   },
   {
+    name: 'NODL',
+    coinType: 1003,
+    passingVectors: [
+      { text: '4k5Am7GnRscesBAG7NEuibjdstLTwBhwtYW1of2FC79DYkqF', hex: '823c7f65123aa9e1fdcfcd146590e7f058a348f282781eebbecc82d20852c627' },
+    ],
+  },
+  {
     name: 'FTM_LEGACY',
     coinType: 1007,
     passingVectors: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -620,6 +620,10 @@ function ksmAddrDecoder(data: string): Buffer {
   return Buffer.from(ss58Decode(data));
 }
 
+function nodlAddrEncoder(data: Buffer): string {
+  return ss58Encode(Uint8Array.from(data), 37);
+}
+
 function ontAddrEncoder(data: Buffer): string {
   return bs58Encode(Buffer.concat([Buffer.from([0x17]), data]))
 }
@@ -1522,6 +1526,7 @@ export const formats: IFormat[] = [
   bech32Chain('RUNE', 931, 'thor'),
   bitcoinChain('BCD', 999, 'bcd', [[0x00]], [[0x05]]),
   hexChecksumChain('TT_LEGACY', 1001),
+  getConfig('NODL', 1003, nodlAddrEncoder, ksmAddrDecoder),
   hexChecksumChain('FTM_LEGACY', 1007),
   bech32Chain('ONE', 1023, 'one'),
   getConfig('ONT', 1024, ontAddrEncoder, ontAddrDecoder),


### PR DESCRIPTION
Add support for the [`nodl`](https://nodle.com) coin. Depends on ensdomains/crypto-addr-serialize/pull/11.