### PR TITLE
Update Optimism address selector with the official ticker

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ This library currently supports the following cryptocurrencies and address forma
  - NULS (base58)
  - ONE (bech32)
  - ONT (base58check)
- - OPT (checksummed-hex)
+ - OP (checksummed-hex)
  - POA (checksummed-hex)
  - PPC (base58check P2PKH and P2SH)
  - QTUM (base58check)

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1125,7 +1125,7 @@ const vectors: Array<TestVector> = [
   },
   // EVM chainIds
   {
-    name: 'OPT',
+    name: 'OP',
     coinType: convertEVMChainIdToCoinType(10),
     passingVectors: [
       { text: '0x314159265dD8dbb310642f98f50C066173C1259b', hex: '314159265dd8dbb310642f98f50c066173c1259b' },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1558,7 +1558,7 @@ export const formats: IFormat[] = [
   getConfig('WAN', 5718350, wanChecksummedHexEncoder, wanChecksummedHexDecoder),
   getConfig('WAVES', 5741564, bs58EncodeNoCheck, wavesAddressDecoder),
   // EVM chainIds
-  evmChain('OPT', 10),
+  evmChain('OP', 10),
   evmChain('BSC', 56),
   evmChain('GO', 60),
   evmChain('ETC', 61),


### PR DESCRIPTION
Changed the Optimism address selector to 'OP' from 'OPT'

## Description
With the official selection of the 'OP' ticker by the Optimism foundation, 'OP' should replace 'OPT' as the selector for Optimism address resolution.

## Reference to the specification
Official selection of OP chain ticker: https://twitter.com/optimismPBC/status/1532110295421829123

## List of features added/changed
Increased accuracy for resolver chain selection

## How much has the filesize increased?
Filesize has decreased by one byte

## Checklist:
- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
- [x] I have specified correct coinTypes specified at [Slip 44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
- [x] I have provided the reference link to the specification I implemented.
- [x] I have provided enough explanation about how I provided the test address
