### PR TITLE
Patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ This library currently supports the following cryptocurrencies and address forma
  - LUNA (bech32)
  - MATIC (checksummed-hex)
  - MONA (base58check P2PKH and P2SH, and bech32 segwit)
+ - MRX (base58check)
  - NANO (nano-base32)
  - NAS(base58 + sha3-256-checksum)
  - NEAR

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -538,6 +538,13 @@ const vectors: Array<TestVector> = [
     ],
   },
   {
+    name: 'MRX',
+    coinType: 326,
+    passingVectors: [
+      { text: 'MPYAKTYDaEMEXWFSxHeMtpXNNiSjK4TVch', hex: '32ab8959869ee2579028abdf6a199b049bfae6dc3b' },
+    ]
+  },
+  {
     name: 'LUNA',
     coinType: 330,
     passingVectors: [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This is a submission to fix some problems in a PR that was reverted.  The network prefix was missing from the hex version of the MRX address. 

## Issue number
<!--- If there is an associated github issues, please specify here -->

## Description
<!--- Describe your changes in detail -->
Added support for MetrixCoin by adding the proper information to the required files.

## Reference to the specification
[QTUM document on WIF](https://blog.qtum.org/wallet-import-format-3497f670b6aa)
MetrixCoin (MRX) is a clone of QTUM and uses the same base58check encoding. Network Id is the only thing that differs.


## Reference to the test address.
[Address from the explorer Richlist](https://explorer.metrixcoin.com/address/MPYAKTYDaEMEXWFSxHeMtpXNNiSjK4TVch/)


## List of features added/changed
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- 
- 

NOTE: If you are adding new coin address support, please make sure to add a reference link to README so that reviewer can verify.

## How much has the filesize increased?

<!-- We are very sensitive about the file size bloat so we may not merge if the file size increase more than 10k. Pleae srun "npm run size" and specify the file size before and after the change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->


<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [x ] My code implements all the required features.
- [x ] I have specified correct coinTypes specified at [Slip 44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
- [x ] I have provided the reference link to the specification I implemented.
- [x ] I have provided enough explanation about how I provided the test address
