### PR TITLE
Add support to EVM compatible Cronos chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This library currently supports the following cryptocurrencies and address forma
  - CELO (checksummed-hex)
  - CKB (bech32)
  - CLO (checksummed-hex)
+ - CRO (checksummed-hex)
  - DASH (base58check P2PKH and P2SH)
  - DCR (base58, no check)
  - DGB (base58check P2PKH and P2SH, and bech32 segwit)

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1132,6 +1132,13 @@ const vectors: Array<TestVector> = [
     ],
   },
   {
+    name: 'CRO',
+    coinType: convertEVMChainIdToCoinType(25),
+    passingVectors: [
+      { text: '0x314159265dD8dbb310642f98f50C066173C1259b', hex: '314159265dd8dbb310642f98f50c066173c1259b' },
+    ],
+  },
+  {
     name: 'BSC',
     coinType: convertEVMChainIdToCoinType(56),
     passingVectors: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1559,6 +1559,7 @@ export const formats: IFormat[] = [
   getConfig('WAVES', 5741564, bs58EncodeNoCheck, wavesAddressDecoder),
   // EVM chainIds
   evmChain('OP', 10),
+  evmChain('CRO', 25),
   evmChain('BSC', 56),
   evmChain('GO', 60),
   evmChain('ETC', 61),


### PR DESCRIPTION
## Description

Adds support for CRO. Cronos Chain is EVM compatible and has the same address format as Ethereum.

## Reference to the specification

https://cronos.org/docs/chain-details/introduction.html

https://cronos.org/docs/getting-started/

https://github.com/crypto-org-chain/cronos

## Reference to the test address.

https://cronos.org/explorer/address/0x314159265dD8dbb310642f98f50C066173C1259b/transactions

## List of features added/changed

- Added support for Cronos Chain (CRO)

## How much has the filesize increased?

It hasn't.

## How Has This Been Tested?

Add a test case for the CRO.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
- [x] I have specified correct coinTypes specified at [Slip 44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
- [x] I have provided the reference link to the specification I implemented.
- [x] I have provided enough explanation about how I provided the test address
