### PR TITLE
Return  any non registered evmchain coin types as ETH

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1309,7 +1309,6 @@ test("support non listed EVM chain coin types if above slip44 msb", () => {
   const nonRegisteredNumber = SLIP44_MSB + 1
   const coinTypes = vectors.map(v => v.coinType)
   const ethType = formatsByCoinType[60]
-  console.log({nonRegisteredNumber, ethType})
   expect(coinTypes.includes(nonRegisteredNumber)).toBe(false);
   expect(formatsByCoinType[nonRegisteredNumber]).toBe(ethType);
 })

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1310,7 +1310,11 @@ test("support non listed EVM chain coin types if above slip44 msb", () => {
   const coinTypes = vectors.map(v => v.coinType)
   const ethType = formatsByCoinType[60]
   expect(coinTypes.includes(nonRegisteredNumber)).toBe(false);
-  expect(formatsByCoinType[nonRegisteredNumber]).toBe(ethType);
+  const result = formatsByCoinType[nonRegisteredNumber];
+  expect(result.coinType).toBe(nonRegisteredNumber);
+  expect(result.name).toBe('');
+  expect(result.encoder).toBe(ethType.encoder);
+  expect(result.decoder).toBe(ethType.decoder);
 })
 
 test("does not support non listed EVM chain coin types if below slip44 msb", () => {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { IFormat, formats, formatsByName, formatsByCoinType, convertEVMChainIdToCoinType, convertCoinTypeToEVMChainId } from '../index';
+import { IFormat, formats, formatsByName, formatsByCoinType, convertEVMChainIdToCoinType, convertCoinTypeToEVMChainId, SLIP44_MSB } from '../index';
 
 interface TestVector {
   name: string;
@@ -1304,6 +1304,22 @@ vectors.forEach((vector: TestVector) => {
     }
   });
 });
+
+test("support non listed EVM chain coin types if above slip44 msb", () => {
+  const nonRegisteredNumber = SLIP44_MSB + 1
+  const coinTypes = vectors.map(v => v.coinType)
+  const ethType = formatsByCoinType[60]
+  console.log({nonRegisteredNumber, ethType})
+  expect(coinTypes.includes(nonRegisteredNumber)).toBe(false);
+  expect(formatsByCoinType[nonRegisteredNumber]).toBe(ethType);
+})
+
+test("does not support non listed EVM chain coin types if below slip44 msb", () => {
+  const nonRegisteredNumber = SLIP44_MSB - 1
+  const coinTypes = vectors.map(v => v.coinType)
+  expect(coinTypes.includes(nonRegisteredNumber)).toBe(false);
+  expect(formatsByCoinType[nonRegisteredNumber]).toBe(undefined);
+})
 
 test("Format ordering", () => {
   lastCointype = -1;

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,5 +1,7 @@
 import fs from 'fs';
-import { IFormat, formats, formatsByName, formatsByCoinType, convertEVMChainIdToCoinType, convertCoinTypeToEVMChainId, SLIP44_MSB, EVM_MSB } from '../index';
+import { IFormat, formats, formatsByName, formatsByCoinType, convertEVMChainIdToCoinType, convertCoinTypeToEVMChainId, SLIP44_MSB } from '../index';
+
+const EVM_MSB = 0xffffffff;
 
 interface TestVector {
   name: string;
@@ -1325,7 +1327,7 @@ test("does not support non listed EVM chain coin types if below slip44 msb", () 
 })
 
 test("does not support non listed EVM chain coin types if equal or above evmid msb", () => {
-  const nonRegisteredNumber = EVM_MSB
+  const nonRegisteredNumber = EVM_MSB + 1
   const coinTypes = vectors.map(v => v.coinType)
   expect(coinTypes.includes(nonRegisteredNumber)).toBe(false);
   expect(formatsByCoinType[nonRegisteredNumber]).toBe(undefined);
@@ -1364,18 +1366,18 @@ test("Convert cointype to evm chain id and convert back", () => {
 
 test("Cannot convert evm chain id to cointype if too high", () => {
   expect(() => {
-    convertEVMChainIdToCoinType(EVM_MSB - SLIP44_MSB)
-  }).toThrow('chainId 2147483648 must be between 1 and 2147483648');
+    convertEVMChainIdToCoinType(EVM_MSB - SLIP44_MSB + 1)
+  }).toThrow('chainId 2147483648 must be less than 2147483648');
 })
 
 test("Cannot convert coinType to evm chain id if too high", () => {
   expect(() => {
-    convertCoinTypeToEVMChainId(EVM_MSB)
-  }).toThrow('coinType 4294967296 must be between 2147483648 and 4294967295');
+    convertCoinTypeToEVMChainId(EVM_MSB + 1)
+  }).toThrow('coinType 4294967296 is not an EVM chain');
 })
 
 test("Cannot convert coinType to evm chain id if too low", () => {
   expect(() => {
     convertCoinTypeToEVMChainId(SLIP44_MSB - 1)
-  }).toThrow('coinType 2147483647 must be between 2147483648 and 4294967295');
+  }).toThrow('coinType 2147483647 is not an EVM chain');
 })

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { IFormat, formats, formatsByName, formatsByCoinType, convertEVMChainIdToCoinType, convertCoinTypeToEVMChainId, SLIP44_MSB } from '../index';
+import { IFormat, formats, formatsByName, formatsByCoinType, convertEVMChainIdToCoinType, convertCoinTypeToEVMChainId, SLIP44_MSB, EVM_MSB } from '../index';
 
 interface TestVector {
   name: string;
@@ -1324,6 +1324,13 @@ test("does not support non listed EVM chain coin types if below slip44 msb", () 
   expect(formatsByCoinType[nonRegisteredNumber]).toBe(undefined);
 })
 
+test("does not support non listed EVM chain coin types if equal or above evmid msb", () => {
+  const nonRegisteredNumber = EVM_MSB
+  const coinTypes = vectors.map(v => v.coinType)
+  expect(coinTypes.includes(nonRegisteredNumber)).toBe(false);
+  expect(formatsByCoinType[nonRegisteredNumber]).toBe(undefined);
+})
+
 test("Format ordering", () => {
   lastCointype = -1;
   formats.forEach((format: IFormat) => {
@@ -1353,4 +1360,22 @@ test("Convert cointype to evm chain id and convert back", () => {
   const gno = 61
   const coinType = convertEVMChainIdToCoinType(gno)
   expect(convertCoinTypeToEVMChainId(coinType)).toBe(gno)
+})
+
+test("Cannot convert evm chain id to cointype if too high", () => {
+  expect(() => {
+    convertEVMChainIdToCoinType(EVM_MSB - SLIP44_MSB)
+  }).toThrow('chainId 2147483648 must be between 1 and 2147483648');
+})
+
+test("Cannot convert coinType to evm chain id if too high", () => {
+  expect(() => {
+    convertCoinTypeToEVMChainId(EVM_MSB)
+  }).toThrow('coinType 4294967296 must be between 2147483648 and 4294967295');
+})
+
+test("Cannot convert coinType to evm chain id if too low", () => {
+  expect(() => {
+    convertCoinTypeToEVMChainId(SLIP44_MSB - 1)
+  }).toThrow('coinType 2147483647 must be between 2147483648 and 4294967295');
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -507,7 +507,7 @@ const hexChecksumChain = (name: string, coinType: number, chainId?: number) => (
 
 /* tslint:disable:no-bitwise */
 export const convertEVMChainIdToCoinType = (chainId: number) =>{
-  if( (chainId + SLIP44_MSB) >= EVM_MSB ){
+  if( chainId >= SLIP44_MSB ){
     throw Error(`chainId ${chainId} must be between 1 and ${EVM_MSB - SLIP44_MSB}`)
   }
   return  (SLIP44_MSB | chainId) >>> 0

--- a/src/index.ts
+++ b/src/index.ts
@@ -1625,7 +1625,7 @@ const handler = {
     const coinType = parseInt(prop, 10)
     if(target[prop]){
       return target[prop]
-    }else if(coinType > SLIP44_MSB && coinType < EVM_MSB){
+    }else if(coinType & SLIP44_MSB  != 0){
       const eth = target[60]
       const { encoder, decoder } = eth
       return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1616,10 +1616,18 @@ const coinTypeFormats: { [key: number]: IFormat } = Object.assign(
 );
 const handler = {
   get(target:any, prop:string) {
+    const coinType = parseInt(prop)
     if(target[prop]){
       return target[prop]
-    }else if(parseInt(prop) > SLIP44_MSB){
-      return target[60]
+    }else if(coinType > SLIP44_MSB){
+      const eth = target[60]
+      let {encoder, decoder} = eth
+      return {
+        coinType,
+        decoder,
+        encoder,
+        name:''
+      }
     }  
   },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -514,8 +514,8 @@ export const convertEVMChainIdToCoinType = (chainId: number) =>{
 
 /* tslint:disable:no-bitwise */
 export const convertCoinTypeToEVMChainId = (coinType: number) =>{
-  if( coinType >= EVM_MSB || coinType < SLIP44_MSB ){
-    throw Error(`coinType ${coinType} must be between ${SLIP44_MSB} and ${EVM_MSB -1}`)
+  if( coinType & SLIP44_MSB == 0 ){
+    throw Error(`coinType ${coinType} is not an EVM chain`)
   }
   return  ((SLIP44_MSB - 1) & coinType) >> 0
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -507,14 +507,14 @@ const hexChecksumChain = (name: string, coinType: number, chainId?: number) => (
 /* tslint:disable:no-bitwise */
 export const convertEVMChainIdToCoinType = (chainId: number) =>{
   if( chainId >= SLIP44_MSB ){
-    throw Error(`chainId ${chainId} must be between 1 and ${EVM_MSB - SLIP44_MSB}`)
+    throw Error(`chainId ${chainId} must be less than ${SLIP44_MSB}`)
   }
   return  (SLIP44_MSB | chainId) >>> 0
 }
 
 /* tslint:disable:no-bitwise */
 export const convertCoinTypeToEVMChainId = (coinType: number) =>{
-  if( coinType & SLIP44_MSB == 0 ){
+  if( (coinType & SLIP44_MSB) === 0 ){
     throw Error(`coinType ${coinType} is not an EVM chain`)
   }
   return  ((SLIP44_MSB - 1) & coinType) >> 0
@@ -1625,7 +1625,8 @@ const handler = {
     const coinType = parseInt(prop, 10)
     if(target[prop]){
       return target[prop]
-    }else if(coinType & SLIP44_MSB  != 0){
+      /* tslint:disable:no-bitwise */
+    } else if((coinType & SLIP44_MSB) !== 0){
       const eth = target[60]
       const { encoder, decoder } = eth
       return {
@@ -1634,7 +1635,7 @@ const handler = {
         encoder,
         name:''
       }
-    }  
+    }
   },
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ const {
 } = bech32;
 
 export const SLIP44_MSB = 0x80000000
+export const EVM_MSB = 0x100000000
 type EnCoder = (data: Buffer) => string;
 type DeCoder = (data: string) => Buffer;
 
@@ -506,11 +507,17 @@ const hexChecksumChain = (name: string, coinType: number, chainId?: number) => (
 
 /* tslint:disable:no-bitwise */
 export const convertEVMChainIdToCoinType = (chainId: number) =>{
+  if( (chainId + SLIP44_MSB) >= EVM_MSB ){
+    throw Error(`chainId ${chainId} must be between 1 and ${EVM_MSB - SLIP44_MSB}`)
+  }
   return  (SLIP44_MSB | chainId) >>> 0
 }
 
 /* tslint:disable:no-bitwise */
 export const convertCoinTypeToEVMChainId = (coinType: number) =>{
+  if( coinType >= EVM_MSB || coinType < SLIP44_MSB ){
+    throw Error(`coinType ${coinType} must be between ${SLIP44_MSB} and ${EVM_MSB -1}`)
+  }
   return  ((SLIP44_MSB -1) & coinType) >> 0
 }
 
@@ -1619,7 +1626,7 @@ const handler = {
     const coinType = parseInt(prop, 10)
     if(target[prop]){
       return target[prop]
-    }else if(coinType > SLIP44_MSB){
+    }else if(coinType > SLIP44_MSB && coinType < EVM_MSB){
       const eth = target[60]
       const { encoder, decoder } = eth
       return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -517,7 +517,7 @@ export const convertCoinTypeToEVMChainId = (coinType: number) =>{
   if( coinType >= EVM_MSB || coinType < SLIP44_MSB ){
     throw Error(`coinType ${coinType} must be between ${SLIP44_MSB} and ${EVM_MSB -1}`)
   }
-  return  ((SLIP44_MSB -1) & coinType) >> 0
+  return  ((SLIP44_MSB - 1) & coinType) >> 0
 }
 
 const evmChain = (name: string, coinType: number) => ({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1616,12 +1616,12 @@ const coinTypeFormats: { [key: number]: IFormat } = Object.assign(
 );
 const handler = {
   get(target:any, prop:string) {
-    const coinType = parseInt(prop)
+    const coinType = parseInt(prop, 10)
     if(target[prop]){
       return target[prop]
     }else if(coinType > SLIP44_MSB){
       const eth = target[60]
-      let {encoder, decoder} = eth
+      const { encoder, decoder } = eth
       return {
         coinType,
         decoder,

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ const {
   toWords: bech32ToWords
 } = bech32;
 
-const SLIP44_MSB = 0x80000000
+export const SLIP44_MSB = 0x80000000
 type EnCoder = (data: Buffer) => string;
 type DeCoder = (data: string) => Buffer;
 
@@ -1610,7 +1610,18 @@ export const formats: IFormat[] = [
 ];
 
 export const formatsByName: { [key: string]: IFormat } = Object.assign({}, ...formats.map(x => ({ [x.name]: x })));
-export const formatsByCoinType: { [key: number]: IFormat } = Object.assign(
+const coinTypeFormats: { [key: number]: IFormat } = Object.assign(
   {},
   ...formats.map(x => ({ [x.coinType]: x })),
 );
+const handler = {
+  get(target:any, prop:string) {
+    if(target[prop]){
+      return target[prop]
+    }else if(parseInt(prop) > SLIP44_MSB){
+      return target[60]
+    }  
+  },
+};
+
+export const formatsByCoinType = new Proxy(coinTypeFormats, handler);

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,6 @@ const {
 } = bech32;
 
 export const SLIP44_MSB = 0x80000000
-export const EVM_MSB = 0x100000000
 type EnCoder = (data: Buffer) => string;
 type DeCoder = (data: string) => Buffer;
 


### PR DESCRIPTION
This change extends `formatsByCoinType` to return ETH encoder/decoder even when specific evm chain id is not registered.

Example:
```js
// registered
encoder.formatsByCoinType[encoder.convertEVMChainIdToCoinType(100)]
{
  coinType: 2147483748,
  decoder: [Function (anonymous)],
  encoder: [Function (anonymous)],
  name: 'GNO'
}
// non registered
encoder.formatsByCoinType[encoder.convertEVMChainIdToCoinType(100123)]
{
  coinType: 2147583771,
  decoder: [Function (anonymous)],
  encoder: [Function (anonymous)],
  name: ''
}
```

Additionally `convertEVMChainIdToCoinType` and `convertCoinTypeToEVMChainId` throws an error if too small/large numbers are passed
