### PR TITLE
Nostr support

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ This library currently supports the following cryptocurrencies and address forma
 - XLM (ed25519 public key)
 - XMR (base58xmr)
 - XRP (base58check-ripple)
+- Nostr (bech32)
 - XTZ (base58check)
 - XVG (base58check P2PKH and P2SH)
 - ZEC (transparent addresses: base58check P2PKH and P2SH, and Sapling shielded payment addresses: bech32; doesn't support Sprout shielded payment addresses)

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -915,6 +915,14 @@ const vectors: Array<TestVector> = [
     ],
   },
   {
+    name: 'NOSTR',
+    coinType: 1237,
+    passingVectors: [
+      { text: 'npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6', hex: '3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d' },
+      { text: 'npub10elfcs4fr0l0r8af98jlmgdh9c8tcxjvz9qkw038js35mp4dma8qzvjptg', hex: '7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e' },
+    ],
+  },
+  {
     name: 'XTZ',
     coinType: 1729,
     passingVectors: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1555,6 +1555,7 @@ export const formats: IFormat[] = [
   hexChecksumChain('FTM_LEGACY', 1007),
   bech32Chain('ONE', 1023, 'one'),
   getConfig('ONT', 1024, ontAddrEncoder, ontAddrDecoder),
+  bech32Chain('NOSTR', 1237, 'npub'),
   {
     coinType: 1729,
     decoder: tezosAddressDecoder,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Support for Nostr addresses. Nostr is a censorship-resistant global social network.

## Issue number
<!--- If there is an associated github issues, please specify here -->

## Description
Nostr uses bech32 and secp256k1-Schnorr which is easy to support. There is no chain and it is a non-financial cointype. I don't know what the policy is on that but I think it would be neat to have in ENS.

## Reference to the specification
[NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md) bech32 instructions.
I have confirmed the cointype number in SLIP-44.


## Reference to the test address.
Two test cases provided by [NIP-19].


## List of features added/changed
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- implement with `bech32chain`
- add test vector
- add to [README](https://github.com/lourkeur/address-encoder/blob/nostr/README.md?plain=1#L154)

## How much has the filesize increased?

<!-- We are very sensitive about the file size bloat so we may not merge if the file size increase more than 10k. Pleae srun "npm run size" and specify the file size before and after the change -->
24 bytes (413915-413891)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
`npm test`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
- [x] I have specified correct coinTypes specified at [Slip 44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
- [x] I have provided the reference link to the specification I implemented.
- [x] I have provided enough explanation about how I provided the test address
