### PR TITLE
Add Endurance EVM Chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ console.log(addr); // 1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa
 This library currently supports the following cryptocurrencies and address formats (ordered alphabetically):
 
 - ABBC (base58 + ripemd160-checksum)
+- ACE (checksummed-hex)
 - ADA (base58, no check + crc32-checksum and bech32)
 - AE (base58check)
 - AIB (base58check P2PKH and P2SH)

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1255,6 +1255,13 @@ const vectors: Array<TestVector> = [
     ],
   },
   {
+    name: 'ACE',
+    coinType: convertEVMChainIdToCoinType(648),
+    passingVectors: [
+      { text: '0x314159265dD8dbb310642f98f50C066173C1259b', hex: '314159265dd8dbb310642f98f50c066173c1259b' },
+    ],
+  },
+  {
     name: 'CLO',
     coinType: convertEVMChainIdToCoinType(820),
     passingVectors: [
@@ -1288,14 +1295,7 @@ const vectors: Array<TestVector> = [
     passingVectors: [
       { text: '0x67316300f17f063085Ca8bCa4bd3f7a5a3C66275', hex: '67316300f17f063085ca8bca4bd3f7a5a3c66275' },
     ],
-  },
-  {
-    name: 'ACE',
-    coinType: convertEVMChainIdToCoinType(648),
-    passingVectors: [
-      { text: '0x314159265dD8dbb310642f98f50C066173C1259b', hex: '314159265dd8dbb310642f98f50c066173c1259b' },
-    ],
-  },
+  }
 ];
 
 var lastCointype = -1;

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1288,7 +1288,14 @@ const vectors: Array<TestVector> = [
     passingVectors: [
       { text: '0x67316300f17f063085Ca8bCa4bd3f7a5a3C66275', hex: '67316300f17f063085ca8bca4bd3f7a5a3c66275' },
     ],
-  }
+  },
+  {
+    name: 'ACE',
+    coinType: convertEVMChainIdToCoinType(648),
+    passingVectors: [
+      { text: '0x314159265dD8dbb310642f98f50C066173C1259b', hex: '314159265dd8dbb310642f98f50c066173c1259b' },
+    ],
+  },
 ];
 
 var lastCointype = -1;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1609,12 +1609,12 @@ export const formats: IFormat[] = [
   evmChain('EWT', 246),
   evmChain('FTM', 250),
   evmChain('THETA', 361),
+  evmChain('ACE', 648),
   evmChain('CLO', 820),
   evmChain('NRG', 39797),
   evmChain('ARB1', 42161),
   evmChain('CELO', 42220),
-  evmChain('AVAXC', 43114),
-  evmChain('ACE', 648)
+  evmChain('AVAXC', 43114)
 ];
 
 export const formatsByName: { [key: string]: IFormat } = Object.assign({}, ...formats.map(x => ({ [x.name]: x })));

--- a/src/index.ts
+++ b/src/index.ts
@@ -1613,7 +1613,8 @@ export const formats: IFormat[] = [
   evmChain('NRG', 39797),
   evmChain('ARB1', 42161),
   evmChain('CELO', 42220),
-  evmChain('AVAXC', 43114)
+  evmChain('AVAXC', 43114),
+  evmChain('ACE', 648)
 ];
 
 export const formatsByName: { [key: string]: IFormat } = Object.assign({}, ...formats.map(x => ({ [x.name]: x })));


### PR DESCRIPTION
## Description
Added `ACE` the native coin from Endurance EVM Chain. 

## Reference to the test address.
https://explorer-endurance.fusionist.io
Endurance,  being an EVM Chain, adding it to Slip44 is not required, and following the last merge that implements `convertEVMChainIdToCoinType` added the ChainID to proceed with the correct conversion.


## List of features added/changed
- Added ACE on `README.md`
- Added ACE on `src/index.ts`
- Added ACE test case on `src/__tests__/index.test.ts`


## How much has the file size increased?
- Before: 416859
- After: 416873
- Difference: 14

## How Has This Been Tested?
Run `yarn test` with zero issues.


## Checklist:
- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
- [ ] I have specified correct coinTypes specified at [Slip 44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
- [x] I have provided the reference link to the specification I implemented.
- [x] I have provided enough explanation about how I provided the test address
