### PR TITLE
Banano support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ This library currently supports the following cryptocurrencies and address forma
 - ATOM (bech32)
 - AVAX (bech32)
 - AVAXC (checksummed-hex)
+- BANANO (banano-base32)
 - BCD (base58check P2PKH and P2SH, and bech32 segwit)
 - BCH (base58check and cashAddr; decodes to cashAddr)
 - BCN (base58xmr)

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -442,6 +442,20 @@ const vectors: Array<TestVector> = [
     ],
   },
   {
+    name: 'BAN',
+    coinType: 198,
+    passingVectors: [
+      {
+        text: 'ban_15dng9kx49xfumkm4q6qpaxneie6oynebiwpums3ktdd6t3f3dhp69nxgb38',
+        hex: '0d7471e5d11faddce5315c97b23b464184afa8c4c396dcf219696b2682d0adf6'
+      },
+      {
+        text: 'ban_1anrzcuwe64rwxzcco8dkhpyxpi8kd7zsjc1oeimpc3ppca4mrjtwnqposrs',
+        hex: '2298fab7c61058e77ea554cb93edeeda0692cbfcc540ab213b2836b29029e23a'
+      }
+    ],
+  },
+  {
     name: 'BCN',
     coinType: 204,
     passingVectors: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1261,6 +1261,22 @@ function nanoAddressDecoder(data: string): Buffer {
   return Buffer.from(decoded).slice(0, -5);
 }
 
+function bananoAddressEncoder(data: Buffer): string {
+  const encoded = nanoBase32Encode(Uint8Array.from(data));
+  const checksum = blake2b(Uint8Array.from(data), null, 5).reverse();
+  const checksumEncoded = nanoBase32Encode(checksum);
+
+  const address = `ban_${encoded}${checksumEncoded}`;
+
+  return address;
+}
+
+function bananoAddressDecoder(data: string): Buffer {
+  const decoded = nanoBase32Decode(data.slice(4));
+
+  return Buffer.from(decoded).slice(0, -5);
+}
+
 function etnAddressEncoder(data: Buffer): string {
   const buf = Buffer.concat([Buffer.from([18]), data]);
 
@@ -1507,6 +1523,7 @@ export const formats: IFormat[] = [
   bitcoinChain('LCC', 192, 'lcc', [[0x1c]], [[0x32], [0x05]]),
   eosioChain('EOS', 194, 'EOS'),
   getConfig('TRX', 195, bs58Encode, bs58Decode),
+  getConfig('BAN', 198, bananoAddressEncoder, bananoAddressDecoder),
   getConfig('BCN', 204, bcnAddressEncoder, bcnAddressDecoder),
   eosioChain('FIO', 235, 'FIO'),
   getConfig('BSV', 236, bsvAddresEncoder, bsvAddressDecoder),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue number
<!--- If there is an associated github issues, please specify here -->

## Description
Support Banano coin type.
As Nano is already supported, this is a trivial change.

## Reference to the specification
Banano is a popular meme coin, forked from Nano.
Yellow Paper available here: https://banano.cc/yellowpaper

## Reference to the test address.
Reused Nano addresses as the encoding is the same, besides `nano_` prefix being `ban_` instead.

## List of features added/changed
[x] added Banano support

## How much has the filesize increased?

416859 -> 417071

## How Has This Been Tested?
Copied the Nano test dataset for Banano.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
- [x] I have specified correct coinTypes specified at [Slip 44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
- [x] I have provided the reference link to the specification I implemented.
- [x] I have provided enough explanation about how I provided the test address
