### PR TITLE
feat: support unknown evm chains

### DIFF
--- a/src/async.test.ts
+++ b/src/async.test.ts
@@ -27,6 +27,7 @@ test("evm coin name", async () => {
   expect(coder.coinType).toBe(2147483658);
   expect(coder.name).toBe("op");
   expect(coder.evmChainId).toBe(10);
+  expect("isUnknownChain" in coder).toBeFalse();
 });
 
 test("evm coin type", async () => {
@@ -34,6 +35,15 @@ test("evm coin type", async () => {
   expect(coder.coinType).toBe(2147483658);
   expect(coder.name).toBe("op");
   expect(coder.evmChainId).toBe(10);
+  expect(coder.isUnknownChain).toBeFalse();
+});
+
+test("unknown evm coin type", async () => {
+  const coder = await getCoderByCoinTypeAsync(2147483659);
+  expect(coder.coinType).toBe(2147483659);
+  expect(coder.name).toBe("Unknown Chain (11)");
+  expect(coder.evmChainId).toBe(11);
+  expect(coder.isUnknownChain).toBeTrue();
 });
 
 const nonEvmCoinNames = Object.keys(nonEvmCoinNameToTypeMap);

--- a/src/async.ts
+++ b/src/async.ts
@@ -46,24 +46,24 @@ export const getCoderByCoinTypeAsync = async <
   const names =
     coinTypeToNameMap[String(coinType) as keyof typeof coinTypeToNameMap];
 
-  if (!names) throw new Error(`Unsupported coin type: ${coinType}`);
-
-  const [name] = names;
-
   if (coinType >= SLIP44_MSB) {
     // EVM coin
     const evmChainId = coinTypeToEvmChainId(coinType);
+    const isUnknownChain = !names;
+    const name = isUnknownChain ? `Unknown Chain (${evmChainId})` : names[0];
     return {
       name,
       coinType: coinType as EvmCoinType,
       evmChainId,
+      isUnknownChain,
       encode: eth.encode,
       decode: eth.decode,
     } as GetCoderByCoinType<TCoinType>;
   }
+
+  if (!names) throw new Error(`Unsupported coin type: ${coinType}`);
+  const [name] = names;
   const mod = await import(`./coin/${name}`);
-
   if (!mod) throw new Error(`Failed to load coin: ${name}`);
-
   return mod[name];
 };

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -44,6 +44,16 @@ test("evm coin type", () => {
   expect(coder.decode).toBeFunction();
 });
 
+test("unknown evm coin type", () => {
+  const coder = getCoderByCoinType(2147483659);
+  expect(coder.coinType).toBe(2147483659);
+  expect(coder.name).toBe("Unknown Chain (11)");
+  expect(coder.evmChainId).toBe(11);
+  expect(coder.isUnknownChain).toBeTrue();
+  expect(coder.encode).toBeFunction();
+  expect(coder.decode).toBeFunction();
+});
+
 const nonEvmCoinNames = Object.keys(nonEvmCoinNameToTypeMap);
 const evmCoinNames = Object.keys(evmCoinNameToTypeMap);
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -31,6 +31,7 @@ test("evm coin name", () => {
   expect(coder.coinType).toBe(2147483658);
   expect(coder.name).toBe("op");
   expect(coder.evmChainId).toBe(10);
+  expect("isUnknownChain" in coder).toBeFalse();
   expect(coder.encode).toBeFunction();
   expect(coder.decode).toBeFunction();
 });
@@ -40,6 +41,7 @@ test("evm coin type", () => {
   expect(coder.coinType).toBe(2147483658);
   expect(coder.name).toBe("op");
   expect(coder.evmChainId).toBe(10);
+  expect(coder.isUnknownChain).toBeFalse();
   expect(coder.encode).toBeFunction();
   expect(coder.decode).toBeFunction();
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,21 +66,24 @@ export const getCoderByCoinName = <
 };
 
 export const getCoderByCoinType = <
-  TCoinType extends CoinType | number = CoinType | number
+  const TCoinType extends CoinType | number = CoinType | number
 >(
   coinType: TCoinType
 ): GetCoderByCoinType<TCoinType> => {
-  const names = coinTypeToNameMap[String(coinType) as keyof typeof coinTypeToNameMap];
+  const names =
+    coinTypeToNameMap[String(coinType) as keyof typeof coinTypeToNameMap];
   // https://docs.ens.domains/ens-improvement-proposals/ensip-11-evmchain-address-resolution
   if (coinType >= SLIP44_MSB) {
     // EVM coin
     const evmChainId = coinTypeToEvmChainId(coinType);
-    const name = names ? names[0] : `Chain(${evmChainId})`; // name is derivable
+    const isUnknownChain = !names;
+    const name = isUnknownChain ? `Unknown Chain (${evmChainId})` : names[0]; // name is derivable
     const ethFormat = formats["eth"];
     return {
       name,
       coinType: coinType as EvmCoinType,
       evmChainId,
+      isUnknownChain,
       encode: ethFormat.encode,
       decode: ethFormat.decode,
     } as GetCoderByCoinType<TCoinType>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ export const getCoderByCoinName = <
 };
 
 export const getCoderByCoinType = <
-  const TCoinType extends CoinType | number = CoinType | number
+  TCoinType extends CoinType | number = CoinType | number
 >(
   coinType: TCoinType
 ): GetCoderByCoinType<TCoinType> => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,15 +70,12 @@ export const getCoderByCoinType = <
 >(
   coinType: TCoinType
 ): GetCoderByCoinType<TCoinType> => {
-  const names =
-    coinTypeToNameMap[String(coinType) as keyof typeof coinTypeToNameMap];
-  if (!names) {
-    throw new Error(`Unsupported coin type: ${coinType}`);
-  }
-  const [name] = names;
+  const names = coinTypeToNameMap[String(coinType) as keyof typeof coinTypeToNameMap];
+  // https://docs.ens.domains/ens-improvement-proposals/ensip-11-evmchain-address-resolution
   if (coinType >= SLIP44_MSB) {
     // EVM coin
     const evmChainId = coinTypeToEvmChainId(coinType);
+    const name = names ? names[0] : `Chain(${evmChainId})`; // name is derivable
     const ethFormat = formats["eth"];
     return {
       name,
@@ -87,7 +84,12 @@ export const getCoderByCoinType = <
       encode: ethFormat.encode,
       decode: ethFormat.decode,
     } as GetCoderByCoinType<TCoinType>;
+  } else {
+    if (!names) {
+      throw new Error(`Unsupported coin type: ${coinType}`);
+    }
+    const [name] = names;
+    const format = formats[name as keyof typeof formats];
+    return format as GetCoderByCoinType<TCoinType>;
   }
-  const format = formats[name as keyof typeof formats];
-  return format as GetCoderByCoinType<TCoinType>;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ export const getCoderByCoinType = <
   const names =
     coinTypeToNameMap[String(coinType) as keyof typeof coinTypeToNameMap];
   // https://docs.ens.domains/ens-improvement-proposals/ensip-11-evmchain-address-resolution
+
   if (coinType >= SLIP44_MSB) {
     // EVM coin
     const evmChainId = coinTypeToEvmChainId(coinType);
@@ -87,12 +88,12 @@ export const getCoderByCoinType = <
       encode: ethFormat.encode,
       decode: ethFormat.decode,
     } as GetCoderByCoinType<TCoinType>;
-  } else {
-    if (!names) {
-      throw new Error(`Unsupported coin type: ${coinType}`);
-    }
-    const [name] = names;
-    const format = formats[name as keyof typeof formats];
-    return format as GetCoderByCoinType<TCoinType>;
   }
+
+  if (!names) {
+    throw new Error(`Unsupported coin type: ${coinType}`);
+  }
+  const [name] = names;
+  const format = formats[name as keyof typeof formats];
+  return format as GetCoderByCoinType<TCoinType>;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,9 @@ export type CoinTypeToFormatMap = {
     : never;
 };
 export type CoinNameToFormatMap = {
-  [key in CoinName]: CoinTypeToFormatMap[CoinNameToTypeMap[key]];
+  [key in CoinName]: Prettify<
+    Omit<CoinTypeToFormatMap[CoinNameToTypeMap[key]], "isUnknownChain">
+  >;
 };
 
 export type EvmCoinMap = typeof evmCoinNameToTypeMap;

--- a/src/utils/evm.test.ts
+++ b/src/utils/evm.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import {
+  coinTypeToEvmChainId,
+  evmChainIdToCoinType,
+  isEvmCoinType,
+} from "./evm.js";
+
+describe("isEvmCoinType()", () => {
+  test("non evm coin type", () => {
+    expect(isEvmCoinType(1000)).toBeFalse();
+  });
+  test("evm coin type", () => {
+    expect(isEvmCoinType(2147483658)).toBeTrue();
+  });
+});
+
+describe("evmChainIdToCoinType()", () => {
+  test("normal chainId", () => {
+    expect(evmChainIdToCoinType(10)).toBe(2147483658);
+  });
+  test("chainId too large", () => {
+    expect(() => evmChainIdToCoinType(2147483648)).toThrow("Invalid chainId");
+  });
+});
+
+describe("coinTypeToEvmChainId()", () => {
+  test("non evm coin type", () => {
+    expect(() => coinTypeToEvmChainId(1000)).toThrow(
+      "Coin type is not an EVM chain"
+    );
+  });
+  test("evm coin type", () => {
+    expect(coinTypeToEvmChainId(2147483658)).toBe(10);
+  });
+});

--- a/src/utils/evm.ts
+++ b/src/utils/evm.ts
@@ -1,7 +1,19 @@
-import type { Add, Lt, Subtract } from "ts-arithmetic";
+import type { Add, GtOrEq, Lt, Subtract } from "ts-arithmetic";
 import type { EvmChainId, EvmCoinType } from "../types.js";
 
 export const SLIP44_MSB = 0x80000000;
+
+export const isEvmCoinType = <
+  TCoinType extends EvmCoinType | number = EvmCoinType | number
+>(
+  coinType: TCoinType
+) =>
+  ((coinType & SLIP44_MSB) !== 0) as GtOrEq<
+    TCoinType,
+    typeof SLIP44_MSB
+  > extends 1
+    ? true
+    : false;
 
 type EvmChainIdToCoinType<
   TChainId extends EvmChainId | number = EvmChainId | number

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -41,6 +41,7 @@ export {
   SLIP44_MSB,
   coinTypeToEvmChainId,
   evmChainIdToCoinType,
+  isEvmCoinType,
 } from "./evm.js";
 export { validateFlowAddress } from "./flow.js";
 export { decodeLeb128, encodeLeb128 } from "./leb128.js";


### PR DESCRIPTION
continuation of #398 with types

changes:
- any arbitrary evm coin type value now has a corresponding coder, via `getCoderByCoinType` and `getCoderByCoinTypeAsync`
  - unknown evm chains have a name formatted as: `Unknown Chain (${chainId})`
  - unknown evm chains have `isUnknownChain` set to true
- added `isEvmCoinType` helper function
- all funcs are still fully typed with unknown chains!