### PR TITLE
Update bitcoinEncoder and bitcoinDecoder as per BIP350 with taproot support

### DIFF
--- a/src/coin/btc.test.ts
+++ b/src/coin/btc.test.ts
@@ -16,18 +16,26 @@ describe.each([
     hex: "0014751e76e8199196d454941c45d1b3a323f1433bd6",
   },
   {
-    text: "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx",
+    text: "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kt5nd6y",
     hex: "5128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6",
   },
-  { text: "bc1sw50qa3jx3s", hex: "6002751e" },
+  { text: "bc1sw50qgdz25j", hex: "6002751e" },
   {
-    text: "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj",
+    text: "bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs",
     hex: "5210751e76e8199196d454941c45d1b3a323",
   },
   {
     text: "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",
     hex: "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
   },
+  {
+    text: "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",
+    hex: "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
+  },
+  {
+    text: "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0",
+    hex: "512079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+  }
 ])("btc address", ({ text, hex }) => {
   test(`encode: ${text}`, () => {
     expect(encodeBtcAddress(hexToBytes(hex))).toEqual(text);

--- a/src/coin/btg.test.ts
+++ b/src/coin/btg.test.ts
@@ -12,11 +12,11 @@ describe.each([
     hex: "a9145ece0cadddc415b1980f001785947120acdb36fc87",
   },
   {
-    text: "btg1zw508d6qejxtdg4y5r3zarvaryv2eet8g",
+    text: "btg1zw508d6qejxtdg4y5r3zarvaryvl9f8z2",
     hex: "5210751e76e8199196d454941c45d1b3a323",
   },
   {
-    text: "btg1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kc36v4c",
+    text: "btg1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kdd2qs6",
     hex: "5128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6",
   },
 ])("btg address", ({ text, hex }) => {

--- a/src/coin/mona.test.ts
+++ b/src/coin/mona.test.ts
@@ -12,7 +12,7 @@ describe.each([
     hex: "a9146449f568c9cd2378138f2636e1567112a184a9e887",
   },
   {
-    text: "mona1zw508d6qejxtdg4y5r3zarvaryvhm3vz7",
+    text: "mona1zw508d6qejxtdg4y5r3zarvaryvz8pq8u",
     hex: "5210751e76e8199196d454941c45d1b3a323",
   },
 ])("mona address", ({ text, hex }) => {

--- a/src/utils/bitcoin.ts
+++ b/src/utils/bitcoin.ts
@@ -6,6 +6,7 @@ import {
 import {
   createBech32SegwitDecoder,
   createBech32SegwitEncoder,
+  createBech32mTaprootDecoder,
 } from "./bech32.js";
 
 export type BitcoinCoderParameters = {
@@ -20,13 +21,18 @@ export const createBitcoinDecoder = ({
   p2shVersions,
 }: BitcoinCoderParameters) => {
   const decodeBech32 = createBech32SegwitDecoder(hrp);
+  const decodeBech32m = createBech32mTaprootDecoder(hrp);
   const decodeBase58 = createBase58VersionedDecoder(
     p2pkhVersions,
     p2shVersions
   );
   return (source: string): Uint8Array => {
     if (source.toLowerCase().startsWith(hrp + "1")) {
-      return decodeBech32(source);
+      try {
+        return decodeBech32(source);
+      } catch (error) {
+        return decodeBech32m(source);
+      }
     }
     return decodeBase58(source);
   };


### PR DESCRIPTION
Changes:
* Update bitcoinEncoder and bitcoinDecoder as per BIP350
* Now BTC, BTG, MONA addresses can support BIP350/taproot support
* Updated outdated test vectors to comply with BIP350 where in addresses for segregated witness outputs version 1 through 16 should use Bech32m.

Outdated Test Vectors:
- Seg Wit address for `6002751e` as per BIP350 should be `bc1sw50qgdz25j` instead of `bc1sw50qa3jx3s` as per previous outdated bitoinEncoder test 
- Seg Wit address for `5210751e76e8199196d454941c45d1b3a323` as per BIP350 should be `bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs` instead of `bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj` as per previous outdated bitoinEncoder test 
- Seg Wit address for `5128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6` as per BIP 350 should be `bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kt5nd6y`  instead of "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx" as per previous outdated bitoinEncoder test 


Reference Links:
https://bitcoin.sipa.be/bech32/demo/demo.html
https://github.com/bitcoin/bips/blob/b3701faef2bdb98a0d7ace4eedbeefa2da4c89ed/bip-0350.mediawiki#user-content-Test_vectors_for_Bech32m
https://github.com/sipa/bech32/blob/master/ref/javascript/tests.js